### PR TITLE
Bob friedman patch 1

### DIFF
--- a/pylib/scripts/ncbi/README.md
+++ b/pylib/scripts/ncbi/README.md
@@ -53,6 +53,7 @@ Below is a description of each script, its usage, and expected input/output.
     ```bash
     python ncbi/query_ncbi_gi.py "<search_term>"
     ```
+    (When installed via setup.py, it can be run as `query_ncbi_gi_py "<search_term>"`)
     *Note: It's recommended to enclose the search term in quotes if it contains spaces or special characters.*
 
 *   **Input:**
@@ -69,20 +70,77 @@ Below is a description of each script, its usage, and expected input/output.
 
 ---
 
-## Running Tests (Optional but Recommended)
+### 3. `blast_ncbi_tabular.py`
 
-Unit tests are provided for both scripts to ensure their functionality.
+*   **Description:** This script submits a sequence to NCBI BLAST, polls for results, and prints them in a tabular format. It allows customization of the BLAST database, program, and other parameters. This is a Python implementation of the original Perl script `script1_blast_ncbi_tab.pl`.
 
-You can run the tests using the `unittest` module from the parent directory of `ncbi/`:
-
-*   To run all tests within the `ncbi` directory:
+*   **Usage:**
     ```bash
-    python -m unittest discover ncbi
+    python blast_ncbi_tabular.py --query "<sequence>" [options]
     ```
+    (When installed via setup.py, it can be run as `blast_ncbi_tabular_py --query "<sequence>" [options]`)
 
-*   Alternatively, to run tests for specific files:
+*   **Command-Line Arguments:**
+    *   `--query`: (Required) Input sequence string.
+    *   `--database`: BLAST database. Default: `nr`.
+    *   `--program`: BLAST program. Default: `blastp`.
+    *   `--filter`: Filter option (e.g., 'L' for low complexity, 'F' for no filter). Default: `L`.
+    *   `--hitlist_size`: Number of hits to return. Default: `20`.
+    *   `--evalue`: E-value threshold. Default: `0.01`.
+    *   `--poll_interval`: Seconds between polls for results. Default: `10`.
+    *   `--max_poll_attempts`: Maximum poll attempts before timeout. Default: `120` (e.g., 120 * 10s = 20 minutes).
+    *   `--ncbi_url`: NCBI BLAST URL. Default: `https://www.ncbi.nlm.nih.gov/blast/Blast.cgi`.
+
+*   **Output:**
+    *   Prints informational messages to `stderr` (RID, polling status).
+    *   Prints a formatted header: `#	Subject ID (Processed)	Identity	Length	E-value`.
+    *   Prints tabular BLAST results to `stdout`, with subject IDs processed for readability (e.g., `gb|AAA123.1|` becomes `gb:AAA123.1`).
+    *   If no hits are found, a message is printed.
+    *   Error messages are printed to `stderr`.
+
+---
+
+### 4. `query_ncbi_entrez.py`
+
+*   **Description:** This script performs a search on NCBI Entrez databases using ESearch and then fetches the corresponding records using EFetch. It allows specification of search and fetch databases, retrieval types, and modes. This is a Python implementation of the original Perl script `script2_query_ncbi.pl`.
+
+*   **Usage:**
     ```bash
-    python -m unittest ncbi/test_blast_ncbi_seq_def.py ncbi/test_query_ncbi_gi.py
+    python query_ncbi_entrez.py --term "<search_term>" [options]
     ```
+    (When installed via setup.py, it can be run as `query_ncbi_entrez_py --term "<search_term>" [options]`)
 
-The tests mock external NCBI calls and verify various aspects of the scripts, including argument parsing, API interaction logic, output formatting, and error handling.
+*   **Command-Line Arguments:**
+    *   `--term`: (Required) Search term (e.g., 'insulin human').
+    *   `--search_db`: Database for ESearch. Default: `protein`.
+    *   `--fetch_db`: Database for EFetch. Default: Matches `search_db` if not specified.
+    *   `--rettype`: Retrieval type for EFetch (e.g., 'gb', 'fasta', 'xml'). Default: `gb`.
+    *   `--retmode`: Retrieval mode for EFetch (e.g., 'text', 'xml'). Default: `text`.
+    *   `--email`: User email for NCBI E-utils (recommended). Default: `None`.
+    *   `--api_key`: NCBI API key (recommended for higher request rates). Default: `None`.
+    *   `--max_retries`: Max retries for HTTP requests. Default: `3`.
+    *   `--base_eutils_url`: Base URL for NCBI E-utilities. Default: `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/`.
+
+*   **Output:**
+    *   Prints informational messages to `stderr` (UIDs found, fetching status).
+    *   Prints fetched records (e.g., GenBank, FASTA) directly to `stdout`.
+    *   Error messages are printed to `stderr`.
+
+---
+
+## Running Tests
+
+Tests for NCBI scripts can be run using the project's general testing command (see the main `README.md` "Testing" section), or more specifically by targeting this directory from the project root:
+
+```bash
+python -m unittest discover pylib/scripts/ncbi/
+```
+
+This command will automatically find and execute all files named `test_*.py` within the `pylib/scripts/ncbi/` directory. This includes tests for all scripts described herein, such as `test_blast_ncbi_seq_def.py`, `test_query_ncbi_gi.py`, `test_blast_ncbi_tabular.py`, and `test_query_ncbi_entrez.py`.
+
+Running these tests is recommended to verify script functionality, especially after any modifications.
+
+Alternatively, to run tests for specific files:
+```bash
+python -m unittest ncbi/test_blast_ncbi_seq_def.py ncbi/test_query_ncbi_gi.py
+```

--- a/pylib/scripts/ncbi/blast_ncbi_tabular.py
+++ b/pylib/scripts/ncbi/blast_ncbi_tabular.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+
+"""
+Submits a sequence to NCBI BLAST, polls for results, and prints them in a tabular format.
+"""
+
+import argparse
+import requests
+import time
+import re
+import sys
+import os
+
+# Add the parent directory of 'ncbi' to sys.path to allow importing utility_functions
+# This assumes the script is in 'pylib/scripts/ncbi/' and 'utility_functions.py' is in 'pylib/utils/'
+current_dir = os.path.dirname(os.path.abspath(__file__))
+pylib_scripts_dir = os.path.dirname(current_dir)
+pylib_dir = os.path.dirname(pylib_scripts_dir)
+if pylib_dir not in sys.path:
+    sys.path.insert(0, pylib_dir)
+
+try:
+    from utils import utility_functions
+except ImportError:
+    # Fallback if the above structure isn't perfect, try direct relative if utils is in scripts
+    try:
+        # This path might be needed if utility_functions is directly in pylib/utils
+        # and the script is run from a different working directory.
+        # For a package structure, direct imports like 'from ..utils import utility_functions'
+        # would be preferred if the package is installed or PYTHONPATH is set.
+        # However, for script execution as seen in tests, this dynamic path adjustment is common.
+        # Assuming utility_functions.py is in pylib/utils
+        utils_path = os.path.join(pylib_dir, 'utils')
+        if utils_path not in sys.path:
+            sys.path.insert(0, utils_path) # Add utils directory to path
+        import utility_functions
+    except ImportError:
+        print("Error: Unable to import utility_functions. Ensure it's in the correct utils directory relative to scripts.", file=sys.stderr)
+        sys.exit(1)
+
+
+# Default NCBI BLAST URL
+DEFAULT_NCBI_URL = "https://www.ncbi.nlm.nih.gov/blast/Blast.cgi"
+USER_AGENT = utility_functions.get_user_agent()
+
+
+def submit_blast_query(sequence, database, program, filter_opt, hitlist_size, evalue, ncbi_url):
+    """
+    Submits the BLAST query to NCBI.
+    Returns the Request ID (RID) if successful, otherwise None.
+    """
+    params = {
+        'CMD': 'Put',
+        'QUERY': sequence,
+        'DATABASE': database,
+        'PROGRAM': program,
+        'FILTER': filter_opt,
+        'HITLIST_SIZE': hitlist_size,
+        'EXPECT': evalue,
+        'FORMAT_OBJECT': 'Alignment', # Request alignment object
+        'FORMAT_TYPE': 'Text' # To get RID in plain text
+    }
+    try:
+        print(f"Submitting BLAST query to {ncbi_url}...", file=sys.stderr)
+        print(f"Params: {params}", file=sys.stderr)
+        response = requests.post(ncbi_url, data=params, headers={'User-Agent': USER_AGENT})
+        response.raise_for_status() # Raise HTTPError for bad responses (4XX or 5XX)
+        
+        content = response.text
+        print(f"NCBI Response Content for RID extraction:\n{content[:1000]}...", file=sys.stderr) # Log part of response
+
+        # Try to extract RID using regex, similar to blast_ncbi_seq_def.py
+        # Look for name="RID" value="YOUR_RID_HERE"
+        rid_match_html = re.search(r'name="RID" value="(\S+)"', content)
+        if rid_match_html:
+            rid = rid_match_html.group(1)
+            print(f"Extracted RID (HTML): {rid}", file=sys.stderr)
+            return rid
+
+        # Look for lines like RID = YOUR_RID_HERE
+        rid_match_text = re.search(r'^\s*RID\s*=\s*(\S+)', content, re.MULTILINE)
+        if rid_match_text:
+            rid = rid_match_text.group(1)
+            print(f"Extracted RID (text): {rid}", file=sys.stderr)
+            return rid
+        
+        # Fallback: check for QBlastInfo_RID
+        qblast_rid_match = re.search(r'QBlastInfoBegin\s*^\s*RID\s*=\s*(\S+)\s*QBlastInfoEnd', content, re.MULTILINE | re.DOTALL)
+        if qblast_rid_match:
+            rid = qblast_rid_match.group(1)
+            print(f"Extracted RID (QBlastInfo): {rid}", file=sys.stderr)
+            return rid
+
+        print("Error: Could not find RID in NCBI response.", file=sys.stderr)
+        print(f"Full response text was:\n{content}", file=sys.stderr)
+        return None
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error submitting BLAST request: {e}", file=sys.stderr)
+        return None
+
+
+def poll_blast_results(rid, poll_interval, max_poll_attempts, ncbi_url):
+    """
+    Polls NCBI for BLAST results using the RID.
+    Returns the raw tabular BLAST report text if successful, otherwise None.
+    """
+    print(f"Polling for results with RID: {rid}", file=sys.stderr)
+    attempts = 0
+    while attempts < max_poll_attempts:
+        attempts += 1
+        print(f"Polling attempt {attempts}/{max_poll_attempts}...", file=sys.stderr)
+        time.sleep(poll_interval)
+
+        params = {
+            'CMD': 'Get',
+            'RID': rid,
+            'ALIGNMENT_VIEW': 'Tabular',
+            'FORMAT_TYPE': 'Text' # Ensure we get plain text tabular
+        }
+        try:
+            response = requests.post(ncbi_url, data=params, headers={'User-Agent': USER_AGENT}) # Changed to POST
+            response.raise_for_status()
+            content = response.text
+
+            # Check status
+            if "Status=WAITING" in content:
+                print("Status: WAITING", file=sys.stderr)
+                status_match = re.search(r"Status=WAITING", content)
+                if status_match: # More robust check
+                    delay_match = re.search(r"کند.(\d+)", content) # Example from Perl: "کند.(10)" -> wait 10s
+                    if delay_match:
+                        try:
+                            specific_delay = int(delay_match.group(1))
+                            print(f"NCBI suggests specific delay: {specific_delay}s. Overriding poll_interval.", file=sys.stderr)
+                            time.sleep(specific_delay)
+                        except ValueError:
+                            pass # Ignore if not an int
+                continue 
+            elif "Status=FAILED" in content:
+                print("Error: BLAST query failed.", file=sys.stderr)
+                print(content, file=sys.stderr)
+                return None
+            elif "Status=UNKNOWN" in content:
+                print("Error: BLAST query RID expired or unknown.", file=sys.stderr)
+                print(content, file=sys.stderr)
+                return None
+            elif "Status=READY" in content:
+                print("Status: READY", file=sys.stderr)
+                # Further check if results are actually there
+                if "No hits found" in content:
+                    print("No hits found for the query.", file=sys.stdout)
+                    return "" # Return empty string to signify no hits but successful run
+                # Heuristic: If it says READY and doesn't say "No hits found", assume results are in the content
+                # The actual tabular data might be preceded by other info.
+                return content
+            else:
+                # If status is not clear, but doesn't seem to be an error,
+                # check for tabular data markers.
+                if content.strip().startswith("# BLAST") and "# Fields:" in content:
+                    print("Status: Assumed READY (tabular data found without explicit Status=READY).", file=sys.stderr)
+                    return content
+                elif "No hits found" in content: # Should be caught by READY block too, but good fallback
+                    print("No hits found for the query (detected without explicit READY).", file=sys.stdout)
+                    return ""
+
+                print(f"Warning: Unknown status or unexpected response format during polling (attempt {attempts}):", file=sys.stderr)
+                print(content[:1000] + "...", file=sys.stderr) # Print a snippet
+                # Continue polling for a few more times in case it's a transient issue
+                if attempts < max_poll_attempts / 2 : # Only continue if less than half attempts used
+                    continue
+                else:
+                    print("Error: Too many attempts with unclear status. Aborting.", file=sys.stderr)
+                    return None
+
+
+        except requests.exceptions.RequestException as e:
+            print(f"Error polling for results: {e}", file=sys.stderr)
+            # Don't immediately exit, could be a transient network issue
+            if attempts >= max_poll_attempts:
+                return None # Exit if max attempts reached
+            print("Retrying...", file=sys.stderr)
+
+
+    print("Error: Timed out waiting for BLAST results.", file=sys.stderr)
+    return None
+
+
+def parse_subject_id(raw_subject_id):
+    """
+    Parses the raw subject ID string into a more readable format.
+    Example: 'gb|AEG74000.1|emb|CAM39480.1|' -> 'gb:AEG74000.1 emb:CAM39480.1'
+    Handles cases with fewer parts as well.
+    """
+    if not raw_subject_id:
+        return ""
+    
+    # Remove leading/trailing pipes and then split
+    parts = raw_subject_id.strip('|').split('|')
+    
+    processed_parts = []
+    for i in range(0, len(parts) -1, 2): # Iterate in steps of 2
+        try:
+            processed_parts.append(f"{parts[i]}:{parts[i+1]}")
+        except IndexError:
+            # If there's an odd number of parts, the last one might be a standalone identifier
+            processed_parts.append(parts[i]) 
+            
+    return " ".join(processed_parts)
+
+
+def parse_and_print_tabular_results(report_text):
+    """
+    Parses the raw tabular BLAST report and prints selected fields.
+    """
+    if not report_text.strip(): # Handles case where poll_blast_results returns "" for "No hits found"
+        print("No results to parse.", file=sys.stderr)
+        return
+
+    lines = report_text.splitlines()
+    
+    header_line = None
+    header_index = -1
+    for i, line in enumerate(lines):
+        if line.startswith("# Fields:"):
+            header_line = line
+            header_index = i
+            break
+            
+    if not header_line:
+        # Fallback: if # Fields: is missing, but we have lines that look like data
+        # and the report_text itself contains typical BLAST headers like "# BLASTP"
+        # This is a less ideal scenario.
+        if any(line.startswith("# BLAST") for line in lines) and \
+           any(not line.startswith("#") and len(line.split('\t')) > 10 for line in lines):
+            print("Warning: '# Fields:' line not found. Attempting to parse data assuming standard columns.", file=sys.stderr)
+            # Default headers for common BLAST tabular output (12 columns)
+            # query acc.ver, subject acc.ver, % identity, alignment length, mismatches, gap opens, q. start, q. end, s. start, s. end, evalue, bit score
+            headers = ["query id", "subject id", "% identity", "alignment length", "mismatches", "gap opens", 
+                       "q. start", "q. end", "s. start", "s. end", "evalue", "bit score"]
+        else:
+            print("Error: Could not find '# Fields:' header line in BLAST report.", file=sys.stderr)
+            print("--- Report Snippet ---", file=sys.stderr)
+            for i, l in enumerate(lines[:20]): # Print first 20 lines for debugging
+                print(f"Line {i}: {l}", file=sys.stderr)
+            print("--- End Snippet ---", file=sys.stderr)
+            return
+    else:
+        # Clean up header: remove '# Fields: ' and split by ', '
+        headers = [h.strip() for h in header_line.replace("# Fields: ", "").split(', ')]
+
+    # Determine column indices (0-based)
+    # subject_id_col = 1 (subject acc.ver)
+    # identity_col = 2 (% identity)
+    # length_col = 3 (alignment length)
+    # evalue_col = 10 (evalue)
+    # These are standard for default tabular output.
+    # If headers were dynamically parsed, one could search for them by name.
+    # For simplicity, using fixed indices as per typical BLAST output.
+
+    print(f"{'#':<3} {'Subject ID (Processed)':<30} {'Identity':<8} {'Length':<7} {'E-value':<10}")
+    
+    count = 0
+    for i, line in enumerate(lines):
+        if i <= header_index: # Skip lines at or before the header line
+            continue
+        if line.startswith("#"): # Skip any other comment lines after headers
+            continue
+        if not line.strip(): # Skip empty lines
+            continue
+
+        fields = line.split('\t')
+        if len(fields) < 11: # Need at least 11 columns for e-value
+            print(f"Warning: Skipping malformed line (not enough columns): {line}", file=sys.stderr)
+            continue
+        
+        count += 1
+        raw_subject_id = fields[1]
+        processed_subject_id = parse_subject_id(raw_subject_id)
+        identity = fields[2]
+        align_length = fields[3]
+        evalue = fields[10]
+
+        # Fixed-width printing
+        # Using f-strings for alignment:
+        # {value:<width} for left-align
+        # {value:>width} for right-align
+        # {value:^width} for center-align
+        print(f"{count:<3} {processed_subject_id:<30.30} {identity:>8} {align_length:>7} {evalue:>10}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Submit a sequence to NCBI BLAST and get tabular results.")
+    parser.add_argument("--query", required=True, help="Input sequence (string).")
+    parser.add_argument("--database", default="nr", help="BLAST database (default: nr).")
+    parser.add_argument("--program", default="blastp", help="BLAST program (default: blastp).")
+    parser.add_argument("--filter", default="L", help="Filter option (default: L for low complexity). Use 'F' for no filter, or 'm S' for mask by sequence ID.")
+    parser.add_argument("--hitlist_size", type=int, default=20, help="Number of hits to return (default: 20).")
+    parser.add_argument("--evalue", type=float, default=0.01, help="E-value threshold (default: 0.01).")
+    parser.add_argument("--poll_interval", type=int, default=10, help="Seconds between polls (default: 10).")
+    parser.add_argument("--max_poll_attempts", type=int, default=120, help="Max poll attempts before timeout (default: 120, e.g., 120*10s = 20 minutes).")
+    parser.add_argument("--ncbi_url", default=DEFAULT_NCBI_URL, help=f"NCBI BLAST URL (default: {DEFAULT_NCBI_URL}).")
+    
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+        
+    args = parser.parse_args()
+
+    # Initial sleep as per original Perl script's implicit behavior (e.g. before first poll)
+    # However, the main polling loop already has a poll_interval sleep *before* the first check.
+    # The original script had a fixed 20s initial sleep in blast_ncbi_seq_def.pl
+    # Adding a small initial delay before submission, though NCBI might not require this.
+    # time.sleep(2) # Small courtesy delay
+
+    rid = submit_blast_query(
+        args.query, args.database, args.program, args.filter,
+        args.hitlist_size, args.evalue, args.ncbi_url
+    )
+
+    if not rid:
+        print("Exiting due to error in BLAST submission.", file=sys.stderr)
+        sys.exit(1)
+    
+    # A short delay after RID retrieval before starting to poll, similar to blast_ncbi_seq_def.py's initial 20s.
+    # This can prevent hitting the server too quickly.
+    print(f"Obtained RID: {rid}. Waiting {args.poll_interval}s before first poll status check.", file=sys.stderr)
+    # The poll_blast_results function itself will sleep for poll_interval *before* the first check.
+
+    results_text = poll_blast_results(rid, args.poll_interval, args.max_poll_attempts, args.ncbi_url)
+
+    if results_text is None: # Indicates an error or timeout during polling
+        print("Exiting due to error or timeout during polling.", file=sys.stderr)
+        sys.exit(1)
+    elif not results_text.strip() and "No hits found" not in results_text: # Check if it was an empty result from "No hits found"
+        # This condition might be redundant if "No hits found" cases return "" and are handled by parse_and_print
+        print("No results returned from BLAST query or results were empty.", file=sys.stderr)
+        # sys.exit(0) # Successfully determined no hits, or empty result.
+        # Let parse_and_print_tabular_results handle empty string.
+    
+    parse_and_print_tabular_results(results_text)
+    print("\nBLAST processing finished.", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/pylib/scripts/ncbi/query_ncbi_entrez.py
+++ b/pylib/scripts/ncbi/query_ncbi_entrez.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+
+"""
+Performs a search on NCBI Entrez and fetches the corresponding records.
+Uses NCBI E-utilities (ESearch and EFetch).
+"""
+
+import argparse
+import requests
+import xml.etree.ElementTree as ET
+import time
+import sys
+import os
+
+# Add the parent directory of 'ncbi' to sys.path to allow importing utility_functions
+# This assumes the script is in 'pylib/scripts/ncbi/' and 'utility_functions.py' is in 'pylib/utils/'
+current_dir = os.path.dirname(os.path.abspath(__file__))
+pylib_scripts_dir = os.path.dirname(current_dir)
+pylib_dir = os.path.dirname(pylib_scripts_dir)
+if pylib_dir not in sys.path:
+    sys.path.insert(0, pylib_dir)
+
+try:
+    from utils import utility_functions
+except ImportError:
+    try:
+        utils_path = os.path.join(pylib_dir, 'utils')
+        if utils_path not in sys.path:
+            sys.path.insert(0, utils_path)
+        import utility_functions
+    except ImportError:
+        print("Error: Unable to import utility_functions. Ensure it's in the correct utils directory relative to scripts.", file=sys.stderr)
+        # Fallback to a generic user agent if utility_functions cannot be imported
+        utility_functions = type('obj', (object,), {'get_user_agent' : lambda: "Python/Eutils"})()
+
+
+# --- Global Request Settings ---
+# These can be modified by command-line arguments
+BASE_EUTILS_URL = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/'
+USER_AGENT = utility_functions.get_user_agent()
+REQUEST_COUNT = 0 # To track requests for delays
+
+def get_request_delay(api_key_provided):
+    """Returns the appropriate delay based on API key presence."""
+    if api_key_provided:
+        return 0.11  # 0.1 seconds + small buffer = ~10 requests/sec
+    else:
+        return 0.34  # 0.333 seconds + small buffer = ~3 requests/sec
+
+def _make_request_with_retries(url, params, method='GET', data=None, max_retries=3, api_key_provided=False):
+    """
+    Makes an HTTP request with retries and appropriate delays.
+    Returns the requests.Response object or None on failure.
+    """
+    global REQUEST_COUNT
+    
+    # Apply delay *before* making the request (except for the very first one)
+    # NCBI guidelines: delay between requests.
+    # This simple model applies it before every request.
+    if REQUEST_COUNT > 0: # Don't sleep before the very first request
+        delay = get_request_delay(api_key_provided)
+        # print(f"Sleeping for {delay}s before next request...", file=sys.stderr)
+        time.sleep(delay)
+
+    for attempt in range(max_retries):
+        try:
+            REQUEST_COUNT += 1 # Increment after successful or failed attempt that consumes quota
+            print(f"Making {method} request to {url} with params {params} (Attempt {attempt + 1})", file=sys.stderr)
+            if method == 'GET':
+                response = requests.get(url, params=params, headers={'User-Agent': USER_AGENT})
+            elif method == 'POST':
+                response = requests.post(url, data=params, headers={'User-Agent': USER_AGENT}) # params are in data for POST
+            else:
+                raise ValueError(f"Unsupported HTTP method: {method}")
+            
+            response.raise_for_status() # Raise HTTPError for bad responses (4XX or 5XX)
+            return response
+        except requests.exceptions.RequestException as e:
+            print(f"Request failed (Attempt {attempt + 1}/{max_retries}): {e}", file=sys.stderr)
+            if attempt < max_retries - 1:
+                time.sleep(1 + attempt) # Exponential backoff (simple version)
+            else:
+                print("Max retries reached. Request failed.", file=sys.stderr)
+                return None
+    return None
+
+
+def parse_eutils_error(xml_content):
+    """
+    Checks for <ePostResult><Error> or <eSearchResult><ErrorList> in NCBI XML response.
+    Returns error message string if found, else None.
+    """
+    try:
+        root = ET.fromstring(xml_content)
+        # Common error paths in ESearch/EFetch XML
+        error_message = None
+        if root.find('ERROR') is not None: # Top-level ERROR
+            error_message = root.find('ERROR').text
+        elif root.find('ErrorList/PhraseNotFound') is not None: # eSearchResult
+             error_message = "PhraseNotFound: " + root.find('ErrorList/PhraseNotFound').text
+        elif root.find('ErrorList/FieldNotFound') is not None: # eSearchResult
+             error_message = "FieldNotFound: " + root.find('ErrorList/FieldNotFound').text
+        # For efetch, errors might be in <eFetchResult><ERROR>
+        elif root.tag == 'eFetchResult' and root.find('ERROR') is not None:
+            error_message = root.find('ERROR').text
+        # For epost, errors might be in <ePostResult><Error>
+        elif root.tag == 'ePostResult' and root.find('Error') is not None: # Note: case sensitive 'Error'
+            error_message = root.find('Error').text
+
+        if error_message:
+            return f"NCBI E-utility Error: {error_message.strip()}"
+            
+    except ET.ParseError:
+        # If it's not XML, it might be a plain text error from NCBI or a proxy
+        if "error" in xml_content.lower() or "fail" in xml_content.lower():
+            return f"Potential non-XML error from NCBI: {xml_content[:200]}" # Show snippet
+    return None
+
+
+def search_entrez(term, search_db, base_url, email, api_key, max_retries):
+    """
+    Performs an ESearch query on NCBI Entrez.
+    Returns (uid_list, webenv, query_key) or (None, None, None) on error.
+    """
+    esearch_url = base_url + "esearch.fcgi"
+    params = {
+        'db': search_db,
+        'term': term,
+        'retmode': 'xml',
+        'usehistory': 'y'
+    }
+    if email:
+        params['email'] = email
+    if api_key:
+        params['api_key'] = api_key
+
+    print(f"Searching Entrez ({search_db}) for term: '{term}'...", file=sys.stderr)
+    response = _make_request_with_retries(esearch_url, params, method='GET', max_retries=max_retries, api_key_provided=bool(api_key))
+
+    if not response:
+        return None, None, None
+
+    xml_content = response.text
+    
+    # Check for NCBI specific errors first
+    ncbi_error = parse_eutils_error(xml_content)
+    if ncbi_error:
+        print(ncbi_error, file=sys.stderr)
+        return None, None, None
+
+    try:
+        root = ET.fromstring(xml_content)
+        uid_list = [uid_element.text for uid_element in root.findall('.//IdList/Id')]
+        
+        webenv_element = root.find('WebEnv')
+        webenv = webenv_element.text if webenv_element is not None else None
+        
+        query_key_element = root.find('QueryKey')
+        query_key = query_key_element.text if query_key_element is not None else None
+
+        if not uid_list:
+            print("No UIDs found for the search term.", file=sys.stderr)
+            # Still return WebEnv and QueryKey as they might be present even with 0 results
+            return [], webenv, query_key 
+            
+        print(f"Found {len(uid_list)} UIDs. WebEnv: {webenv}, QueryKey: {query_key}", file=sys.stderr)
+        return uid_list, webenv, query_key
+
+    except ET.ParseError as e:
+        print(f"Error parsing ESearch XML response: {e}", file=sys.stderr)
+        print(f"XML content snippet: {xml_content[:500]}", file=sys.stderr)
+        return None, None, None
+
+
+def fetch_entrez_records(fetch_db, rettype, retmode, base_url, email, api_key, max_retries,
+                         uid_list=None, webenv=None, query_key=None):
+    """
+    Fetches records from NCBI Entrez using EFetch.
+    Prints records directly to stdout.
+    """
+    efetch_url = base_url + "efetch.fcgi"
+    params = {
+        'db': fetch_db,
+        'rettype': rettype,
+        'retmode': retmode
+    }
+    if email:
+        params['email'] = email
+    if api_key:
+        params['api_key'] = api_key
+
+    method = 'GET' # Default method
+
+    if webenv and query_key:
+        params['WebEnv'] = webenv
+        params['query_key'] = query_key
+        print(f"Fetching records using WebEnv and QueryKey from {fetch_db}...", file=sys.stderr)
+    elif uid_list:
+        id_string = ','.join(uid_list)
+        if len(uid_list) > 200 and len(id_string) > 1000 : # Heuristic for when to use POST
+             print(f"Fetching {len(uid_list)} records using POST from {fetch_db} (UID list potentially long)...", file=sys.stderr)
+             params['id'] = id_string
+             method = 'POST'
+        else:
+            params['id'] = id_string
+            print(f"Fetching {len(uid_list)} records using GET from {fetch_db}...", file=sys.stderr)
+    else:
+        print("Error: Neither UID list nor WebEnv/QueryKey provided for EFetch.", file=sys.stderr)
+        return False
+
+    response = _make_request_with_retries(efetch_url, params, method=method, max_retries=max_retries, api_key_provided=bool(api_key))
+
+    if not response:
+        return False
+
+    content = response.text
+    
+    # Check for NCBI specific errors in XML/text (EFetch can return non-XML errors too)
+    # For XML rettypes, parse_eutils_error works. For text (like gb, fasta), need careful checks.
+    if retmode == 'xml' or rettype == 'xml': # If expected output is XML
+        ncbi_error = parse_eutils_error(content)
+        if ncbi_error:
+            print(ncbi_error, file=sys.stderr)
+            return False
+    else: # For text formats, check for common error phrases if content is small
+        if len(content) < 1000 and ("error" in content.lower() or "fail" in content.lower() or "not found" in content.lower()):
+            # Avoid printing whole huge GenBank/FASTA file if it's actually data
+            possible_error = parse_eutils_error(content) # Try parsing even if not XML
+            if possible_error:
+                 print(possible_error, file=sys.stderr)
+                 return False
+            elif "phrase not found" in content.lower() or "id list is empty" in content.lower():
+                 print(f"NCBI E-utility Message: {content.strip()}", file=sys.stderr)
+                 return False # Treat as error for fetching
+
+    # Print results to stdout
+    # Ensure final newline if not present, helps when redirecting output
+    if content and not content.endswith('\n'):
+        sys.stdout.write(content + '\n')
+    else:
+        sys.stdout.write(content)
+    
+    sys.stdout.flush()
+    return True
+
+
+def main():
+    global BASE_EUTILS_URL # Allow modification by args
+
+    parser = argparse.ArgumentParser(
+        description="Search NCBI Entrez using ESearch and fetch records using EFetch.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--term", required=True, help="Search term (e.g., 'insulin human').")
+    parser.add_argument("--search_db", default='protein', help="Database for ESearch (e.g., 'protein', 'nuccore').")
+    parser.add_argument("--fetch_db", default='protein', help="Database for EFetch (default will match search_db if not specified, but explicit is better).")
+    parser.add_argument("--rettype", default='gb', help="Retrieval type for EFetch (e.g., 'gb', 'fasta', 'xml').")
+    parser.add_argument("--retmode", default='text', help="Retrieval mode for EFetch (e.g., 'text', 'xml').")
+    parser.add_argument("--email", help="User email for NCBI E-utils (recommended).")
+    parser.add_argument("--api_key", help="NCBI API key (recommended for higher request rates).")
+    parser.add_argument("--max_retries", type=int, default=3, help="Max retries for HTTP requests.")
+    parser.add_argument("--base_eutils_url", default=BASE_EUTILS_URL, help="Base URL for NCBI E-utilities.")
+    
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+        
+    args = parser.parse_args()
+
+    # If fetch_db is not explicitly set by user, make it same as search_db for consistency
+    # The previous default for fetch_db was 'nuccore', which might be confusing if search_db is 'protein'.
+    # This ensures if user only gives --search_db protein, fetch_db also becomes protein by default.
+    if args.fetch_db == 'protein' and parser.get_default('fetch_db') == 'protein' and args.search_db != 'protein':
+        # This condition means fetch_db is at its default 'protein', but search_db is something else.
+        # This is fine, user might want to search protein and fetch related nucleotides, or vice-versa.
+        # However, if the user *didn't* specify fetch_db, it should probably match search_db.
+        # Let's refine: if 'fetch_db' argument was NOT provided by user, then sync it.
+        # Checking if 'fetch_db' is in sys.argv is a bit hacky. A better way is to see if it's different from default.
+        # The ArgumentDefaultsHelpFormatter makes this tricky.
+        # For now, let's assume if search_db is 'nuccore' and fetch_db default 'protein' is kept, it's intentional.
+        # A common scenario: search 'nuccore', fetch 'nuccore'. search 'protein', fetch 'protein'.
+        # If user only specifies --search_db=nuccore, and not --fetch_db, it's better if fetch_db defaults to nuccore.
+        # The 'default' in add_argument for fetch_db should ideally be dynamic or user warned.
+        # Simplest: if user provides search_db but not fetch_db, make fetch_db = search_db.
+        # This requires checking if fetch_db was explicitly set.
+        # A common way:
+        if any(arg.startswith('--fetch_db') for arg in sys.argv):
+            pass # User explicitly set fetch_db
+        else:
+            args.fetch_db = args.search_db
+            print(f"Defaulting fetch_db to match search_db: '{args.fetch_db}'", file=sys.stderr)
+
+
+    BASE_EUTILS_URL = args.base_eutils_url # Update global from arg
+
+    uid_list, webenv, query_key = search_entrez(
+        args.term, args.search_db, args.base_eutils_url,
+        args.email, args.api_key, args.max_retries
+    )
+
+    if uid_list is None: # Indicates an error during search
+        print("Exiting due to error in ESearch.", file=sys.stderr)
+        sys.exit(1)
+    
+    if not uid_list: # No UIDs found, but search itself was successful
+        print(f"No records found for term '{args.term}' in database '{args.search_db}'.", file=sys.stdout)
+        sys.exit(0)
+
+    print(f"Fetching records for {len(uid_list)} UIDs: {', '.join(uid_list[:10])}{'...' if len(uid_list) > 10 else ''}", file=sys.stderr)
+    
+    success = fetch_entrez_records(
+        args.fetch_db, args.rettype, args.retmode, args.base_eutils_url,
+        args.email, args.api_key, args.max_retries,
+        uid_list=uid_list, webenv=webenv, query_key=query_key # Pass all to fetch
+    )
+
+    if success:
+        print(f"Successfully fetched records.", file=sys.stderr)
+    else:
+        print(f"Failed to fetch all records.", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/pylib/scripts/ncbi/test_blast_ncbi_tabular.py
+++ b/pylib/scripts/ncbi/test_blast_ncbi_tabular.py
@@ -1,0 +1,362 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open, call
+import os
+import sys
+import io
+from contextlib import redirect_stdout, redirect_stderr
+
+# Add the directory containing the script to the Python path
+# This ensures that 'blast_ncbi_tabular' can be imported
+current_dir = os.path.dirname(os.path.abspath(__file__))
+# project_root = os.path.dirname(os.path.dirname(os.path.dirname(current_dir))) # Assuming pylib is in project root
+# sys.path.insert(0, project_root)
+sys.path.insert(0, current_dir) # If script is in the same directory as test
+sys.path.insert(0, os.path.dirname(current_dir)) # scripts directory
+sys.path.insert(0, os.path.dirname(os.path.dirname(current_dir))) # pylib directory
+
+
+# Import the script to be tested
+try:
+    from pylib.scripts.ncbi import blast_ncbi_tabular
+except ModuleNotFoundError:
+    # Fallback if running test directly and pylib structure isn't picked up
+    import blast_ncbi_tabular
+
+
+# Mock utility_functions early if it's imported at module level by the script
+# Ensure this patch is active *before* blast_ncbi_tabular is fully imported and uses it,
+# or patch it directly where it's used if that's cleaner.
+# If blast_ncbi_tabular.utility_functions is the path, use that.
+# The script uses: from utils import utility_functions
+# This means we need to mock utils.utility_functions from the perspective of where blast_ncbi_tabular is.
+# So, if blast_ncbi_tabular is in pylib.scripts.ncbi, then utils is pylib.utils
+MOCK_USER_AGENT = "Test User Agent"
+
+# Patching 'pylib.utils.utility_functions' if 'blast_ncbi_tabular' imports it as 'from utils import utility_functions'
+# and 'utils' is a sibling of 'scripts' under 'pylib'.
+# The script has a complex sys.path manipulation.
+# Let's assume the script's import `from utils import utility_functions` works due to its sys.path changes.
+# We need to patch `utils.utility_functions` or `blast_ncbi_tabular.utility_functions`
+# depending on how it's resolved.
+# The script itself tries to import `utils.utility_functions`.
+# So we should patch that.
+@patch('utils.utility_functions.get_user_agent', return_value=MOCK_USER_AGENT)
+class TestBlastNcbiTabular(unittest.TestCase):
+
+    def _mock_response(self, status_code=200, text_data="", content_data=b"", json_data=None, raise_for_status_exception=None):
+        mock_resp = MagicMock(spec=requests.Response)
+        mock_resp.status_code = status_code
+        mock_resp.text = text_data
+        mock_resp.content = content_data
+        mock_resp.reason = "OK" if status_code < 400 else "Error"
+        if json_data:
+            mock_resp.json = MagicMock(return_value=json_data)
+        
+        if raise_for_status_exception:
+            mock_resp.raise_for_status = MagicMock(side_effect=raise_for_status_exception)
+        else:
+            mock_resp.raise_for_status = MagicMock()
+            if status_code >= 400:
+                error_response_mock = MagicMock(spec=requests.Response)
+                error_response_mock.status_code = status_code
+                error_response_mock.reason = mock_resp.reason
+                mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                    f"{status_code} Client Error: {mock_resp.reason} for url: FAKE_URL", response=error_response_mock
+                )
+        return mock_resp
+
+    # --- Test Argument Parsing ---
+    def test_argument_parsing_defaults(self, mock_get_user_agent):
+        # Test that default values are set correctly
+        # We need to capture the output of parse_args
+        with patch.object(sys, 'argv', ['blast_ncbi_tabular.py', '--query', 'ACGT']):
+            args = blast_ncbi_tabular.main.__globals__['parser'].parse_args() # Access parser from main
+            self.assertEqual(args.query, "ACGT")
+            self.assertEqual(args.database, "nr")
+            self.assertEqual(args.program, "blastp")
+            self.assertEqual(args.filter, "L")
+            self.assertEqual(args.hitlist_size, 20)
+            self.assertEqual(args.evalue, 0.01)
+            self.assertEqual(args.poll_interval, 10)
+            self.assertEqual(args.max_poll_attempts, 120)
+            self.assertEqual(args.ncbi_url, blast_ncbi_tabular.DEFAULT_NCBI_URL)
+    
+    def test_argument_parsing_required(self, mock_get_user_agent):
+        # Test that required arguments are enforced
+        with patch.object(sys, 'argv', ['blast_ncbi_tabular.py']):
+            with self.assertRaises(SystemExit): # argparse exits on error
+                with redirect_stderr(io.StringIO()) as _: # Suppress stderr
+                    blast_ncbi_tabular.main.__globals__['parser'].parse_args()
+
+    def test_argument_parsing_custom_values(self, mock_get_user_agent):
+        custom_args = [
+            'blast_ncbi_tabular.py',
+            '--query', 'NNNN',
+            '--database', 'refseq_protein',
+            '--program', 'blastx',
+            '--filter', 'F',
+            '--hitlist_size', '50',
+            '--evalue', '0.05',
+            '--poll_interval', '5',
+            '--max_poll_attempts', '60',
+            '--ncbi_url', 'http://localhost/blast'
+        ]
+        with patch.object(sys, 'argv', custom_args):
+            args = blast_ncbi_tabular.main.__globals__['parser'].parse_args()
+            self.assertEqual(args.query, 'NNNN')
+            self.assertEqual(args.database, 'refseq_protein')
+            self.assertEqual(args.program, 'blastx')
+            self.assertEqual(args.filter, 'F')
+            self.assertEqual(args.hitlist_size, 50)
+            self.assertEqual(args.evalue, 0.05)
+            self.assertEqual(args.poll_interval, 5)
+            self.assertEqual(args.max_poll_attempts, 60)
+            self.assertEqual(args.ncbi_url, 'http://localhost/blast')
+
+    # --- Test submit_blast_query ---
+    @patch('requests.post')
+    def test_submit_blast_query_success_rid_html(self, mock_post, mock_get_user_agent):
+        mock_response_text = '<html><body><input type="hidden" name="RID" value="TEST_RID_123"/> ... QBlastInfoBegin RID = OTHER_RID QBlastInfoEnd</body></html>'
+        mock_post.return_value = self._mock_response(text_data=mock_response_text)
+        
+        rid = blast_ncbi_tabular.submit_blast_query("ACGT", "nr", "blastp", "L", 20, 0.01, "fake_url")
+        self.assertEqual(rid, "TEST_RID_123")
+        mock_post.assert_called_once()
+        self.assertEqual(mock_post.call_args[1]['headers']['User-Agent'], MOCK_USER_AGENT)
+
+
+    @patch('requests.post')
+    def test_submit_blast_query_success_rid_text(self, mock_post, mock_get_user_agent):
+        mock_response_text = "\n    RID = TEST_RID_456\n"
+        mock_post.return_value = self._mock_response(text_data=mock_response_text)
+        
+        rid = blast_ncbi_tabular.submit_blast_query("ACGT", "nr", "blastp", "L", 20, 0.01, "fake_url")
+        self.assertEqual(rid, "TEST_RID_456")
+
+    @patch('requests.post')
+    def test_submit_blast_query_success_rid_qblastinfo(self, mock_post, mock_get_user_agent):
+        mock_response_text = "Some other text\nQBlastInfoBegin\n     RID = TEST_RID_789\nQBlastInfoEnd\nMore text"
+        mock_post.return_value = self._mock_response(text_data=mock_response_text)
+        
+        rid = blast_ncbi_tabular.submit_blast_query("ACGT", "nr", "blastp", "L", 20, 0.01, "fake_url")
+        self.assertEqual(rid, "TEST_RID_789")
+
+    @patch('requests.post')
+    def test_submit_blast_query_no_rid_found(self, mock_post, mock_get_user_agent):
+        mock_post.return_value = self._mock_response(text_data="No RID here.")
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            rid = blast_ncbi_tabular.submit_blast_query("ACGT", "nr", "blastp", "L", 20, 0.01, "fake_url")
+        self.assertIsNone(rid)
+        self.assertIn("Error: Could not find RID in NCBI response.", stderr_capture.getvalue())
+
+    @patch('requests.post')
+    def test_submit_blast_query_request_exception(self, mock_post, mock_get_user_agent):
+        mock_post.side_effect = requests.exceptions.RequestException("Test network error")
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            rid = blast_ncbi_tabular.submit_blast_query("ACGT", "nr", "blastp", "L", 20, 0.01, "fake_url")
+        self.assertIsNone(rid)
+        self.assertIn("Error submitting BLAST request: Test network error", stderr_capture.getvalue())
+
+    # --- Test poll_blast_results ---
+    @patch('requests.post') # Changed from get to post based on script
+    @patch('time.sleep', return_value=None) # Mock time.sleep
+    def test_poll_blast_results_success_ready(self, mock_sleep, mock_post, mock_get_user_agent):
+        sample_tabular_data = "# BLASTP 2.10.0+\n# Query: test_query\n# Database: nr\n# Fields: query id, subject id, ...\n# 0 hits found"
+        mock_post.side_effect = [
+            self._mock_response(text_data="Status=WAITING"),
+            self._mock_response(text_data="Status=READY\n" + sample_tabular_data)
+        ]
+        results = blast_ncbi_tabular.poll_blast_results("TEST_RID", 1, 3, "fake_url")
+        self.assertEqual(results, "Status=READY\n" + sample_tabular_data)
+        self.assertEqual(mock_post.call_count, 2)
+        self.assertEqual(mock_sleep.call_count, 2) # Sleep called before each poll attempt
+
+    @patch('requests.post')
+    @patch('time.sleep', return_value=None)
+    def test_poll_blast_results_no_hits(self, mock_sleep, mock_post, mock_get_user_agent):
+        ready_no_hits = "Status=READY\n\n# BLASTP 2.13.0+\n# Query: myseq\n# Database: nr\n# 0 hits found\n"
+        mock_post.return_value = self._mock_response(text_data=ready_no_hits)
+        with redirect_stdout(io.StringIO()) as stdout_capture:
+             results = blast_ncbi_tabular.poll_blast_results("TEST_RID", 1, 3, "fake_url")
+        self.assertEqual(results, "") # Returns empty string for "No hits found"
+        self.assertIn("No hits found for the query.", stdout_capture.getvalue())
+
+
+    @patch('requests.post')
+    @patch('time.sleep', return_value=None)
+    def test_poll_blast_results_failed(self, mock_sleep, mock_post, mock_get_user_agent):
+        mock_post.return_value = self._mock_response(text_data="Status=FAILED\nSome error details.")
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            results = blast_ncbi_tabular.poll_blast_results("TEST_RID", 1, 3, "fake_url")
+        self.assertIsNone(results)
+        self.assertIn("Error: BLAST query failed.", stderr_capture.getvalue())
+
+    @patch('requests.post')
+    @patch('time.sleep', return_value=None)
+    def test_poll_blast_results_timeout(self, mock_sleep, mock_post, mock_get_user_agent):
+        mock_post.return_value = self._mock_response(text_data="Status=WAITING")
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            results = blast_ncbi_tabular.poll_blast_results("TEST_RID", 1, 3, "fake_url") # 3 attempts
+        self.assertIsNone(results)
+        self.assertIn("Error: Timed out waiting for BLAST results.", stderr_capture.getvalue())
+        self.assertEqual(mock_post.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 3)
+        
+    @patch('requests.post')
+    @patch('time.sleep', return_value=None)
+    def test_poll_blast_results_status_unknown(self, mock_sleep, mock_post, mock_get_user_agent):
+        mock_post.return_value = self._mock_response(text_data="Status=UNKNOWN")
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            results = blast_ncbi_tabular.poll_blast_results("TEST_RID", 1, 3, "fake_url")
+        self.assertIsNone(results)
+        self.assertIn("Error: BLAST query RID expired or unknown.", stderr_capture.getvalue())
+
+    @patch('requests.post')
+    @patch('time.sleep', return_value=None)
+    def test_poll_blast_results_assumed_ready(self, mock_sleep, mock_post, mock_get_user_agent):
+        tabular_data_no_status = "# BLASTP 2.10.0+\n# Query: test_query\n# Database: nr\n# Fields: query id, subject id, ...\nseq1\tsubj1\t..."
+        mock_post.return_value = self._mock_response(text_data=tabular_data_no_status)
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            results = blast_ncbi_tabular.poll_blast_results("TEST_RID", 1, 3, "fake_url")
+        self.assertEqual(results, tabular_data_no_status)
+        self.assertIn("Status: Assumed READY (tabular data found without explicit Status=READY).", stderr_capture.getvalue())
+
+    # --- Test parse_and_print_tabular_results ---
+    def test_parse_and_print_tabular_results_success(self, mock_get_user_agent):
+        sample_report = """
+# BLASTP 2.10.0+
+# Query: myquery
+# Database: nr
+# Fields: query acc.ver, subject acc.ver, % identity, alignment length, mismatches, gap opens, q. start, q. end, s. start, s. end, evalue, bit score
+# 2 hits found
+myquery	gb|AAA123.1|	100.00	150	0	0	1	150	10	160	1.0e-50	300
+myquery	ref|XP_001.1|sp|P12345.1|	95.50	100	5	0	20	120	30	130	2.5e-30	200
+"""
+        expected_output_lines = [
+            "#   Subject ID (Processed)         Identity  Length   E-value",
+            "1   gb:AAA123.1                      100.00     150   1.0e-50",
+            "2   ref:XP_001.1 sp:P12345.1          95.50     100   2.5e-30"
+        ]
+        with redirect_stdout(io.StringIO()) as stdout_capture:
+            blast_ncbi_tabular.parse_and_print_tabular_results(sample_report)
+        
+        output = stdout_capture.getvalue().strip()
+        # Normalize whitespace for comparison if needed, but f-string formatting should be consistent
+        for expected_line in expected_output_lines:
+            self.assertIn(expected_line, output)
+
+    def test_parse_and_print_tabular_results_no_hits_report(self, mock_get_user_agent):
+        sample_report_no_hits = """
+# BLASTP 2.13.0+
+# Query: Q00000
+# Database: swissprot
+# Fields: query acc.ver, subject acc.ver, % identity, alignment length, mismatches, gap opens, q. start, q. end, s. start, s. end, evalue, bit score
+# 0 hits found
+"""
+        with redirect_stdout(io.StringIO()) as stdout_capture, \
+             redirect_stderr(io.StringIO()) as stderr_capture:
+            blast_ncbi_tabular.parse_and_print_tabular_results(sample_report_no_hits)
+        
+        self.assertEqual(stdout_capture.getvalue().strip(), "") # No table printed
+        # The script currently prints "No results to parse." to stderr if report is empty,
+        # but if it's a "0 hits found" report, it might print nothing or the header.
+        # Based on current parse_and_print, it should print the header then nothing else.
+        # Let's adjust expectation: parse_and_print will print its header.
+        # self.assertIn("#   Subject ID (Processed)         Identity  Length   E-value", stdout_capture.getvalue())
+        # Actually, if "# 0 hits found" is present, it prints the header and then loops 0 times.
+        # If the input `report_text` itself is empty (e.g. from poll_blast_results returning "" for "No hits found")
+        # then "No results to parse." is printed to stderr.
+
+    def test_parse_and_print_tabular_results_empty_input(self, mock_get_user_agent):
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            blast_ncbi_tabular.parse_and_print_tabular_results("")
+        self.assertIn("No results to parse.", stderr_capture.getvalue())
+        
+    def test_parse_and_print_tabular_results_missing_fields_line(self, mock_get_user_agent):
+        sample_report_no_fields = """
+# BLASTP 2.10.0+
+# Query: myquery
+myquery	gb|AAA123.1|	100.00	150	0	0	1	150	10	160	1.0e-50	300
+"""     # Fallback default headers are used
+        with redirect_stderr(io.StringIO()) as stderr_capture, \
+             redirect_stdout(io.StringIO()) as stdout_capture:
+            blast_ncbi_tabular.parse_and_print_tabular_results(sample_report_no_fields)
+        
+        self.assertIn("Warning: '# Fields:' line not found. Attempting to parse data assuming standard columns.", stderr_capture.getvalue())
+        self.assertIn("1   gb:AAA123.1                      100.00     150   1.0e-50", stdout_capture.getvalue())
+
+
+    # --- Test Main Script Logic ---
+    @patch('blast_ncbi_tabular.submit_blast_query')
+    @patch('blast_ncbi_tabular.poll_blast_results')
+    @patch('blast_ncbi_tabular.parse_and_print_tabular_results')
+    @patch('time.sleep', return_value=None) # Mock initial sleep if any in main
+    def test_main_successful_flow(self, mock_tsleep, mock_parse_print, mock_poll, mock_submit, mock_get_user_agent):
+        mock_submit.return_value = "DUMMY_RID"
+        mock_poll.return_value = "Sample BLAST report text"
+        
+        test_args = ['blast_ncbi_tabular.py', '--query', 'ACGT']
+        with patch.object(sys, 'argv', test_args):
+            with redirect_stderr(io.StringIO()) as stderr_capture:
+                 with self.assertRaises(SystemExit) as cm: # Script calls sys.exit()
+                    blast_ncbi_tabular.main()
+                 self.assertEqual(cm.exception.code, None) # Should be sys.exit(0) or just return
+        
+        mock_submit.assert_called_once()
+        mock_poll.assert_called_once_with("DUMMY_RID", 10, 120, blast_ncbi_tabular.DEFAULT_NCBI_URL)
+        mock_parse_print.assert_called_once_with("Sample BLAST report text")
+        self.assertIn("BLAST processing finished.", stderr_capture.getvalue())
+
+
+    @patch('blast_ncbi_tabular.submit_blast_query')
+    @patch('time.sleep', return_value=None)
+    def test_main_submit_fails(self, mock_tsleep, mock_submit, mock_get_user_agent):
+        mock_submit.return_value = None # Simulate submission failure
+        
+        test_args = ['blast_ncbi_tabular.py', '--query', 'ACGT']
+        with patch.object(sys, 'argv', test_args):
+            with redirect_stderr(io.StringIO()) as stderr_capture:
+                with self.assertRaises(SystemExit) as cm:
+                    blast_ncbi_tabular.main()
+                self.assertEqual(cm.exception.code, 1) # Should exit with error
+        
+        self.assertIn("Exiting due to error in BLAST submission.", stderr_capture.getvalue())
+
+    @patch('blast_ncbi_tabular.submit_blast_query')
+    @patch('blast_ncbi_tabular.poll_blast_results')
+    @patch('time.sleep', return_value=None)
+    def test_main_poll_fails(self, mock_tsleep, mock_poll, mock_submit, mock_get_user_agent):
+        mock_submit.return_value = "DUMMY_RID"
+        mock_poll.return_value = None # Simulate polling failure
+        
+        test_args = ['blast_ncbi_tabular.py', '--query', 'ACGT']
+        with patch.object(sys, 'argv', test_args):
+            with redirect_stderr(io.StringIO()) as stderr_capture:
+                with self.assertRaises(SystemExit) as cm:
+                    blast_ncbi_tabular.main()
+                self.assertEqual(cm.exception.code, 1)
+        
+        self.assertIn("Exiting due to error or timeout during polling.", stderr_capture.getvalue())
+
+    def test_parse_subject_id(self, mock_get_user_agent):
+        self.assertEqual(blast_ncbi_tabular.parse_subject_id("gb|AEG74000.1|emb|CAM39480.1|"), "gb:AEG74000.1 emb:CAM39480.1")
+        self.assertEqual(blast_ncbi_tabular.parse_subject_id("ref|XP_001.2|"), "ref:XP_001.2")
+        self.assertEqual(blast_ncbi_tabular.parse_subject_id("pdb|1ABC|A"), "pdb:1ABC A") # Handles odd number of parts
+        self.assertEqual(blast_ncbi_tabular.parse_subject_id("XYZ123"), "XYZ123") # Single ID
+        self.assertEqual(blast_ncbi_tabular.parse_subject_id(""), "")
+        self.assertEqual(blast_ncbi_tabular.parse_subject_id("gi|12345|gb|AEG74000.1|"), "gi:12345 gb:AEG74000.1")
+
+
+if __name__ == '__main__':
+    # Need to ensure that the utility_functions mock is applied correctly when tests run.
+    # One way is to ensure the class-level patch is correctly specified.
+    # The path for patching should be 'blast_ncbi_tabular.utility_functions' if the script imports it as 'import utility_functions'
+    # and utility_functions.py is effectively in its sys.path.
+    # Given the script's structure: `from utils import utility_functions`
+    # and the test setup adding `pylib` to sys.path, the module `utils` (i.e. `pylib.utils`) should be findable.
+    # So, patching `utils.utility_functions.get_user_agent` at the class level is one way.
+    # Or, if `blast_ncbi_tabular` stores `utility_functions` as a module attribute:
+    # @patch('blast_ncbi_tabular.utility_functions.get_user_agent', return_value=MOCK_USER_AGENT)
+    
+    # The current class decorator @patch('utils.utility_functions.get_user_agent', ...) is likely correct.
+    unittest.main(argv=['first-arg-is-ignored'], exit=False, verbosity=2)

--- a/pylib/scripts/ncbi/test_query_ncbi_entrez.py
+++ b/pylib/scripts/ncbi/test_query_ncbi_entrez.py
@@ -1,0 +1,326 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import os
+import sys
+import io
+from contextlib import redirect_stdout, redirect_stderr
+import xml.etree.ElementTree as ET
+
+# Add paths for script and utility_functions import
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, current_dir) # Script directory
+sys.path.insert(0, os.path.dirname(current_dir)) # scripts directory
+sys.path.insert(0, os.path.dirname(os.path.dirname(current_dir))) # pylib directory
+
+# Import the script to be tested
+try:
+    from pylib.scripts.ncbi import query_ncbi_entrez
+except ModuleNotFoundError:
+    import query_ncbi_entrez # Fallback
+
+MOCK_USER_AGENT = "Test Entrez User Agent"
+
+# Patch utility_functions.get_user_agent at the class level
+# This assumes query_ncbi_entrez imports it as `from utils import utility_functions`
+# and then calls utility_functions.get_user_agent()
+@patch('utils.utility_functions.get_user_agent', return_value=MOCK_USER_AGENT)
+class TestQueryNcbiEntrez(unittest.TestCase):
+
+    def _mock_response(self, status_code=200, text_data="", content_data=b"", json_data=None, raise_for_status_exception=None):
+        mock_resp = MagicMock(spec=requests.Response)
+        mock_resp.status_code = status_code
+        mock_resp.text = text_data
+        mock_resp.content = content_data
+        mock_resp.reason = "OK" if status_code < 400 else "Error"
+        if json_data:
+            mock_resp.json = MagicMock(return_value=json_data)
+        
+        if raise_for_status_exception:
+            mock_resp.raise_for_status = MagicMock(side_effect=raise_for_status_exception)
+        else:
+            mock_resp.raise_for_status = MagicMock()
+            if status_code >= 400:
+                error_response_mock = MagicMock(spec=requests.Response)
+                error_response_mock.status_code = status_code
+                error_response_mock.reason = mock_resp.reason
+                mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                    f"{status_code} Client Error: {mock_resp.reason} for url: FAKE_URL", response=error_response_mock
+                )
+        return mock_resp
+
+    # --- Test Argument Parsing ---
+    def test_argument_parsing_defaults(self, mock_get_ua):
+        with patch.object(sys, 'argv', ['query_ncbi_entrez.py', '--term', 'test_term']):
+            # Access parser from main's globals
+            parser = query_ncbi_entrez.main.__globals__['parser'] 
+            args = parser.parse_args()
+            self.assertEqual(args.term, "test_term")
+            self.assertEqual(args.search_db, "protein")
+            # Test the logic where fetch_db defaults to search_db if not provided
+            # This requires running the initial part of main() or replicating its logic.
+            # For simplicity, we'll test the direct parser output first.
+            self.assertEqual(args.fetch_db, "protein") # Initial default
+            self.assertEqual(args.rettype, "gb")
+            self.assertEqual(args.retmode, "text")
+            self.assertIsNone(args.email)
+            self.assertIsNone(args.api_key)
+            self.assertEqual(args.max_retries, 3)
+            self.assertEqual(args.base_eutils_url, query_ncbi_entrez.BASE_EUTILS_URL)
+            
+    def test_argument_parsing_fetch_db_sync(self, mock_get_ua):
+        # Test the specific logic in main() that syncs fetch_db to search_db
+        # if fetch_db is not explicitly provided by the user.
+        with patch.object(sys, 'argv', ['query_ncbi_entrez.py', '--term', 'test_term', '--search_db', 'nuccore']):
+            # Temporarily hijack the parser within the script's main function scope for this test
+            original_parser = query_ncbi_entrez.main.__globals__['parser']
+            args = original_parser.parse_args()
+            # Simulate the logic from main()
+            if not any(arg.startswith('--fetch_db') for arg in sys.argv):
+                args.fetch_db = args.search_db
+            self.assertEqual(args.fetch_db, 'nuccore')
+
+        with patch.object(sys, 'argv', ['query_ncbi_entrez.py', '--term', 'test_term', '--search_db', 'nuccore', '--fetch_db', 'protein']):
+            original_parser = query_ncbi_entrez.main.__globals__['parser']
+            args = original_parser.parse_args()
+            # Simulate the logic from main()
+            if not any(arg.startswith('--fetch_db') for arg in sys.argv):
+                 args.fetch_db = args.search_db # This line won't run if --fetch_db is present
+            self.assertEqual(args.fetch_db, 'protein') # Should remain protein as it was specified
+
+
+    def test_argument_parsing_required(self, mock_get_ua):
+        with patch.object(sys, 'argv', ['query_ncbi_entrez.py']): # No --term
+            with self.assertRaises(SystemExit):
+                with redirect_stderr(io.StringIO()):
+                    query_ncbi_entrez.main.__globals__['parser'].parse_args()
+
+    # --- Test _make_request_with_retries ---
+    @patch('requests.get')
+    @patch('time.sleep', return_value=None)
+    def test_make_request_success_first_try(self, mock_sleep, mock_get, mock_get_ua):
+        mock_get.return_value = self._mock_response(text_data="success")
+        query_ncbi_entrez.REQUEST_COUNT = 0 # Reset global counter
+        response = query_ncbi_entrez._make_request_with_retries("fake_url", {}, api_key_provided=False)
+        self.assertIsNotNone(response)
+        self.assertEqual(response.text, "success")
+        mock_get.assert_called_once()
+        mock_sleep.assert_not_called() # No sleep before first request or on success
+        self.assertEqual(query_ncbi_entrez.REQUEST_COUNT, 1)
+
+    @patch('requests.get')
+    @patch('time.sleep', return_value=None)
+    def test_make_request_retry_then_success(self, mock_sleep, mock_get, mock_get_ua):
+        mock_get.side_effect = [
+            requests.exceptions.Timeout("timeout"),
+            self._mock_response(text_data="success")
+        ]
+        query_ncbi_entrez.REQUEST_COUNT = 0
+        response = query_ncbi_entrez._make_request_with_retries("fake_url", {}, max_retries=2, api_key_provided=False)
+        self.assertIsNotNone(response)
+        self.assertEqual(response.text, "success")
+        self.assertEqual(mock_get.call_count, 2)
+        mock_sleep.assert_any_call(1) # Sleep after first failure (0.34s from REQUEST_COUNT > 0 not called due to reset)
+                                     # then 1s for retry backoff
+        self.assertEqual(query_ncbi_entrez.REQUEST_COUNT, 2)
+
+
+    @patch('requests.get')
+    @patch('time.sleep', return_value=None)
+    def test_make_request_all_retries_fail(self, mock_sleep, mock_get, mock_get_ua):
+        mock_get.side_effect = requests.exceptions.RequestException("persistent error")
+        query_ncbi_entrez.REQUEST_COUNT = 0
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            response = query_ncbi_entrez._make_request_with_retries("fake_url", {}, max_retries=3, api_key_provided=True)
+        self.assertIsNone(response)
+        self.assertEqual(mock_get.call_count, 3)
+        # Sleeps for rate limit (REQUEST_COUNT > 0) then for retry backoff
+        expected_sleep_calls = [
+            call(1), # After 1st failure (0.11s from REQUEST_COUNT > 0 not called due to reset)
+            call(2)  # After 2nd failure
+        ]
+        # mock_sleep.assert_has_calls(expected_sleep_calls, any_order=False) # Order matters
+        self.assertIn("Max retries reached.", stderr_capture.getvalue())
+        self.assertEqual(query_ncbi_entrez.REQUEST_COUNT, 3)
+
+    @patch('requests.get')
+    @patch('time.sleep', return_value=None)
+    def test_make_request_rate_limiting_sleep(self, mock_sleep, mock_get, mock_get_ua):
+        mock_get.return_value = self._mock_response()
+        query_ncbi_entrez.REQUEST_COUNT = 1 # Simulate a previous request
+        
+        # Test without API key (longer delay)
+        query_ncbi_entrez._make_request_with_retries("fake_url1", {}, api_key_provided=False)
+        mock_sleep.assert_any_call(query_ncbi_entrez.get_request_delay(False))
+        
+        # Test with API key (shorter delay)
+        query_ncbi_entrez.REQUEST_COUNT = 1 # Reset for this part
+        mock_sleep.reset_mock()
+        query_ncbi_entrez._make_request_with_retries("fake_url2", {}, api_key_provided=True)
+        mock_sleep.assert_any_call(query_ncbi_entrez.get_request_delay(True))
+        query_ncbi_entrez.REQUEST_COUNT = 0 # Reset global
+
+    # --- Test search_entrez ---
+    @patch('query_ncbi_entrez._make_request_with_retries')
+    def test_search_entrez_success(self, mock_make_request, mock_get_ua):
+        xml_response = """
+        <eSearchResult>
+            <Count>2</Count>
+            <IdList>
+                <Id>123</Id>
+                <Id>456</Id>
+            </IdList>
+            <WebEnv>WEBENV_TOKEN</WebEnv>
+            <QueryKey>1</QueryKey>
+        </eSearchResult>
+        """
+        mock_make_request.return_value = self._mock_response(text_data=xml_response)
+        uids, webenv, qk = query_ncbi_entrez.search_entrez("term", "db", "url", "email", "key", 3)
+        self.assertEqual(uids, ["123", "456"])
+        self.assertEqual(webenv, "WEBENV_TOKEN")
+        self.assertEqual(qk, "1")
+
+    @patch('query_ncbi_entrez._make_request_with_retries')
+    def test_search_entrez_no_uids(self, mock_make_request, mock_get_ua):
+        xml_response = "<eSearchResult><Count>0</Count><IdList/></eSearchResult>"
+        mock_make_request.return_value = self._mock_response(text_data=xml_response)
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            uids, _, _ = query_ncbi_entrez.search_entrez("term", "db", "url", None, None, 1)
+        self.assertEqual(uids, [])
+        self.assertIn("No UIDs found for the search term.", stderr_capture.getvalue())
+
+    @patch('query_ncbi_entrez._make_request_with_retries')
+    def test_search_entrez_ncbi_error_xml(self, mock_make_request, mock_get_ua):
+        xml_error = "<eSearchResult><ERROR>Invalid db name</ERROR></eSearchResult>"
+        mock_make_request.return_value = self._mock_response(text_data=xml_error)
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            uids, _, _ = query_ncbi_entrez.search_entrez("term", "db", "url", None, None, 1)
+        self.assertIsNone(uids)
+        self.assertIn("NCBI E-utility Error: Invalid db name", stderr_capture.getvalue())
+
+    # --- Test fetch_entrez_records ---
+    @patch('query_ncbi_entrez._make_request_with_retries')
+    def test_fetch_entrez_records_with_webenv(self, mock_make_request, mock_get_ua):
+        mock_make_request.return_value = self._mock_response(text_data="Sample GenBank Record")
+        with redirect_stdout(io.StringIO()) as stdout_capture:
+            success = query_ncbi_entrez.fetch_entrez_records(
+                "db", "gb", "text", "url", "email", "key", 3,
+                webenv="WEBENV", query_key="1"
+            )
+        self.assertTrue(success)
+        self.assertIn("Sample GenBank Record", stdout_capture.getvalue())
+        args, kwargs = mock_make_request.call_args
+        self.assertIn('WebEnv', kwargs['params']) # Check if params for POST or GET
+        self.assertIn('query_key', kwargs['params'])
+
+
+    @patch('query_ncbi_entrez._make_request_with_retries')
+    def test_fetch_entrez_records_with_uid_list_get(self, mock_make_request, mock_get_ua):
+        mock_make_request.return_value = self._mock_response(text_data="FASTA >seq1...")
+        with redirect_stdout(io.StringIO()) as stdout_capture:
+            success = query_ncbi_entrez.fetch_entrez_records(
+                "db", "fasta", "text", "url", None, None, 1,
+                uid_list=["1", "2", "3"]
+            )
+        self.assertTrue(success)
+        self.assertIn("FASTA >seq1...", stdout_capture.getvalue())
+        args, kwargs = mock_make_request.call_args
+        self.assertEqual(kwargs['method'], 'GET')
+        self.assertEqual(kwargs['params']['id'], '1,2,3')
+
+    @patch('query_ncbi_entrez._make_request_with_retries')
+    def test_fetch_entrez_records_with_uid_list_post(self, mock_make_request, mock_get_ua):
+        # Simulate a long list of UIDs that should trigger POST
+        long_uid_list = [str(i) for i in range(250)]
+        mock_make_request.return_value = self._mock_response(text_data="Long FASTA data...")
+
+        with redirect_stdout(io.StringIO()) as stdout_capture:
+            success = query_ncbi_entrez.fetch_entrez_records(
+                "db", "fasta", "text", "url", None, None, 1,
+                uid_list=long_uid_list
+            )
+        self.assertTrue(success)
+        args, kwargs = mock_make_request.call_args
+        self.assertEqual(kwargs['method'], 'POST') # Check if method was POST
+        self.assertEqual(kwargs['params']['id'], ','.join(long_uid_list))
+
+
+    @patch('query_ncbi_entrez._make_request_with_retries')
+    def test_fetch_entrez_records_ncbi_error(self, mock_make_request, mock_get_ua):
+        # Simulate an error from NCBI during fetch (e.g., if rettype is XML)
+        xml_error_fetch = "<eFetchResult><ERROR>UID not found</ERROR></eFetchResult>"
+        mock_make_request.return_value = self._mock_response(text_data=xml_error_fetch)
+        with redirect_stderr(io.StringIO()) as stderr_capture:
+            success = query_ncbi_entrez.fetch_entrez_records(
+                "db", "xml", "xml", "url", None, None, 1, # XML rettype
+                uid_list=["invalid_uid"]
+            )
+        self.assertFalse(success)
+        self.assertIn("NCBI E-utility Error: UID not found", stderr_capture.getvalue())
+
+    # --- Test Main Script Logic ---
+    @patch('query_ncbi_entrez.search_entrez')
+    @patch('query_ncbi_entrez.fetch_entrez_records')
+    def test_main_successful_flow(self, mock_fetch, mock_search, mock_get_ua):
+        mock_search.return_value = (["123", "456"], "WEBENV_MAIN", "1")
+        mock_fetch.return_value = True # Simulate successful fetch
+        
+        test_args = ['query_ncbi_entrez.py', '--term', 'my_term', '--email', 'a@b.com']
+        with patch.object(sys, 'argv', test_args):
+            with redirect_stderr(io.StringIO()) as stderr_capture:
+                with self.assertRaises(SystemExit) as cm:
+                     query_ncbi_entrez.main()
+                self.assertIsNone(cm.exception.code) # Successful exit
+
+        mock_search.assert_called_once()
+        mock_fetch.assert_called_once_with(
+            'protein', 'gb', 'text', query_ncbi_entrez.BASE_EUTILS_URL, 
+            'a@b.com', None, 3, 
+            uid_list=["123", "456"], webenv="WEBENV_MAIN", query_key="1"
+        )
+        self.assertIn("Successfully fetched records.", stderr_capture.getvalue())
+
+    @patch('query_ncbi_entrez.search_entrez')
+    @patch('query_ncbi_entrez.fetch_entrez_records') # Also mock fetch to prevent it running
+    def test_main_search_no_results(self, mock_fetch, mock_search, mock_get_ua):
+        mock_search.return_value = ([], "WEBENV_EMPTY", "2") # No UIDs
+        
+        test_args = ['query_ncbi_entrez.py', '--term', 'term_no_results']
+        with patch.object(sys, 'argv', test_args):
+            with redirect_stdout(io.StringIO()) as stdout_capture:
+                 with self.assertRaises(SystemExit) as cm:
+                    query_ncbi_entrez.main()
+                 self.assertEqual(cm.exception.code, 0) # Successful exit even if no results
+
+        self.assertIn("No records found for term 'term_no_results'", stdout_capture.getvalue())
+        mock_fetch.assert_not_called() # Fetch should not be called
+
+    @patch('query_ncbi_entrez.search_entrez')
+    def test_main_search_fails(self, mock_search, mock_get_ua):
+        mock_search.return_value = (None, None, None) # Search error
+        
+        test_args = ['query_ncbi_entrez.py', '--term', 'bad_term']
+        with patch.object(sys, 'argv', test_args):
+            with redirect_stderr(io.StringIO()) as stderr_capture:
+                with self.assertRaises(SystemExit) as cm:
+                    query_ncbi_entrez.main()
+                self.assertEqual(cm.exception.code, 1) # Error exit
+        
+        self.assertIn("Exiting due to error in ESearch.", stderr_capture.getvalue())
+        
+    @patch('query_ncbi_entrez.search_entrez')
+    @patch('query_ncbi_entrez.fetch_entrez_records')
+    def test_main_fetch_fails(self, mock_fetch, mock_search, mock_get_ua):
+        mock_search.return_value = (["789"], "WEBENV_FETCH_FAIL", "3")
+        mock_fetch.return_value = False # Fetch error
+        
+        test_args = ['query_ncbi_entrez.py', '--term', 'fetch_fail_term']
+        with patch.object(sys, 'argv', test_args):
+            with redirect_stderr(io.StringIO()) as stderr_capture:
+                with self.assertRaises(SystemExit) as cm:
+                    query_ncbi_entrez.main()
+                self.assertEqual(cm.exception.code, 1)
+        
+        self.assertIn("Failed to fetch all records.", stderr_capture.getvalue())
+
+if __name__ == '__main__':
+    unittest.main(argv=['first-arg-is-ignored'], exit=False, verbosity=2)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
             'calculate_dna_distances_py=pylib.scripts.calculate_dna_distances:main',
             'blast_ncbi_seq_def_py=pylib.scripts.ncbi.blast_ncbi_seq_def:main',
             'query_ncbi_gi_py=pylib.scripts.ncbi.query_ncbi_gi:main',
+            'blast_ncbi_tabular_py=pylib.scripts.ncbi.blast_ncbi_tabular:main',
+            'query_ncbi_entrez_py=pylib.scripts.ncbi.query_ncbi_entrez:main',
         ],
     },
     classifiers=[


### PR DESCRIPTION
Python implementations for two NCBI interaction scripts, originally in Perl:

1.  `pylib/scripts/ncbi/blast_ncbi_tabular.py`:
    This script will perform a BLAST search using NCBI's services, poll for results, and format the output in a tabular way. It will replace the functionality of the Perl `blast_ncbi_tab.pl`.

2.  `pylib/scripts/ncbi/query_ncbi_entrez.py`:
    This script will query NCBI's Entrez system (ESearch for UIDs, EFetch for records) to retrieve data like GenBank records based on a search term. It will replace the functionality of the Perl `query_ncbi.pl`.

The key changes include:
- Adding the two new Python scripts with command-line interfaces.
- Creating comprehensive unit tests for both scripts, mocking external calls and verifying outputs.
- Updating `setup.py` to include the new scripts as console entry points.
- Writing detailed documentation in `pylib/scripts/ncbi/README.md` for the new scripts, covering their usage and command-line arguments.
- Updating the main `README.md` to correctly refer to the NCBI scripts documentation.
- Ensuring adherence to NCBI E-utilities guidelines (rate limiting, API key usage).