### PR TITLE
Virus genomics documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ This phylogenetic workflow highlights how EvolCat-Python scripts primarily serve
 
 [Phylogenetic Tree Interpretation](https://github.com/bob-friedman/EvolCat-Python/blob/main/phylogenetic-tree-interpretation.md)
 
+### E. Special Topic: Virus Genomics, Diversity, and Analysis
+
+[Guide to Virus Genomics, Diversity, and Analysis](virus_genomics_guide.md)
+
 ## Testing
 
 This project uses Python's built-in `unittest` framework for testing. Unit tests are located alongside the scripts they test within the `pylib/scripts/` directory (e.g., tests for NCBI scripts are in `pylib/scripts/ncbi/`).

--- a/pylib/scripts/viral_tools/calculate_nucleotide_diversity.py
+++ b/pylib/scripts/viral_tools/calculate_nucleotide_diversity.py
@@ -1,0 +1,95 @@
+"""
+Calculates the nucleotide diversity (pi) from a FASTA alignment file.
+
+Nucleotide diversity is defined as the average number of nucleotide
+differences per site between any two DNA sequences chosen randomly from the
+sample population.
+
+pi = (sum of pairwise differences) / (number of pairs)
+Number of pairs = n * (n - 1) / 2, where n is the number of sequences.
+
+Arguments:
+  fasta_file (str): Path to the input FASTA alignment file.
+
+Output:
+  Prints the calculated nucleotide diversity (pi) to standard output.
+"""
+
+import argparse
+from Bio import SeqIO
+import itertools # Will be used for pairwise combinations
+
+def calculate_pairwise_differences(seq1, seq2):
+    """Calculates the number of nucleotide differences between two sequences."""
+    differences = 0
+    # Ensure sequences are of the same length for a meaningful comparison
+    if len(seq1) != len(seq2):
+        raise ValueError("Sequences must be of the same length for comparison.")
+    for i in range(len(seq1)):
+        if seq1[i] != seq2[i]:
+            differences += 1
+    return differences
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate nucleotide diversity (pi) from a FASTA alignment.")
+    parser.add_argument("fasta_file", help="Path to the input FASTA alignment file.")
+    args = parser.parse_args()
+
+    sequences = []
+    try:
+        for record in SeqIO.parse(args.fasta_file, "fasta"):
+            sequences.append(record.seq)
+    except FileNotFoundError:
+        print(f"Error: File not found at {args.fasta_file}")
+        return
+    except Exception as e: # Catch other potential parsing errors
+        print(f"Error parsing FASTA file: {e}")
+        return
+
+    if not sequences:
+        print("No sequences found in the FASTA file.")
+        return
+    
+    num_sequences = len(sequences)
+    if num_sequences < 2:
+        print("Nucleotide diversity calculation requires at least two sequences.")
+        # Pi would be 0 or undefined, depending on interpretation.
+        # For n=0 or n=1, n*(n-1)/2 is 0.
+        # It's clearer to state it requires at least two.
+        return
+
+    # Basic check for alignment: are all sequences of the same length?
+    first_seq_len = len(sequences[0])
+    if not all(len(seq) == first_seq_len for seq in sequences):
+        print("Error: Sequences in the FASTA file are not all of the same length. Please provide an aligned FASTA file.")
+        return
+
+    total_pairwise_differences = 0
+    # Generate all unique pairs of sequences
+    for seq1, seq2 in itertools.combinations(sequences, 2):
+        total_pairwise_differences += calculate_pairwise_differences(seq1, seq2)
+
+    # Calculate number of pairs
+    # n * (n - 1) / 2
+    num_pairs = num_sequences * (num_sequences - 1) / 2
+
+    if num_pairs == 0: # Should be caught by num_sequences < 2, but as a safeguard
+        nucleotide_diversity = 0.0
+    else:
+        # The sum of pairwise differences is for the entire length of sequences.
+        # Nucleotide diversity (pi) is usually expressed per site.
+        # So, we need to divide by the length of the alignment (first_seq_len).
+        if first_seq_len == 0: # Avoid division by zero if sequences are empty
+             print("Error: Sequences are empty (length 0). Cannot calculate diversity per site.")
+             return
+        nucleotide_diversity = total_pairwise_differences / num_pairs / first_seq_len
+
+
+    print(f"Number of sequences: {num_sequences}")
+    print(f"Alignment length: {first_seq_len}")
+    print(f"Total pairwise differences: {total_pairwise_differences}")
+    print(f"Number of pairs: {int(num_pairs)}")
+    print(f"Nucleotide diversity (pi): {nucleotide_diversity:.6f}")
+
+if __name__ == "__main__":
+    main()

--- a/pylib/scripts/viral_tools/calculate_site_specific_ds_dn.py
+++ b/pylib/scripts/viral_tools/calculate_site_specific_ds_dn.py
@@ -1,0 +1,327 @@
+"""
+Wraps PAML's codeml to perform site-specific dN/dS analysis.
+
+This script automates the process of:
+1. Preparing input files (converting alignment to PHYLIP).
+2. Generating a PAML codeml control file (.ctl) based on user inputs.
+3. Running codeml.
+4. Parsing the codeml output.
+5. Summarizing key results and site-specific dN/dS estimates,
+   including Bayes Empirical Bayes (BEB) probabilities for positive selection.
+
+Requires PAML (specifically the 'codeml' executable) to be installed and
+either in the system PATH or its location provided via --paml_path.
+"""
+
+import argparse
+import os
+import sys
+import subprocess
+import shutil
+from Bio import AlignIO, Phylo
+from Bio.Phylo.PAML import codeml, CodemlError
+
+def setup_codeml_options(cml, args):
+    """Sets codeml options based on command-line arguments."""
+    cml.set_options(seqtype=1)  # 1 for codons
+    cml.set_options(noisy=9 if args.verbose else 3)
+    cml.set_options(cleandata=args.cleandata) # 1 to remove sites with gaps/ambiguities
+    cml.set_options(RateAncestor=1) # Required for BEB analysis
+    
+    # Common model parameters
+    cml.set_options(fix_kappa=0) # Estimate kappa
+    cml.set_options(kappa=2.0)   # Initial kappa
+    cml.set_options(fix_omega=0) # Estimate omega
+    cml.set_options(omega=0.5)   # Initial omega (background)
+
+    # Model-specific parameters
+    if args.model == "M0":
+        cml.set_options(model=0)
+        cml.set_options(NSsites=[0])
+    elif args.model == "M1a":
+        cml.set_options(model=0)
+        cml.set_options(NSsites=[1])
+    elif args.model == "M2a":
+        cml.set_options(model=0)
+        cml.set_options(NSsites=[2])
+    elif args.model == "M3":
+        cml.set_options(model=0)
+        cml.set_options(NSsites=[3])
+        cml.set_options(ncatG=args.num_site_categories)
+    elif args.model == "M7":
+        cml.set_options(model=0)
+        cml.set_options(NSsites=[7])
+    elif args.model == "M8":
+        cml.set_options(model=0)
+        cml.set_options(NSsites=[8])
+    else:
+        # This should ideally be caught by argparse choices, but as a safeguard:
+        raise ValueError(f"Unsupported PAML model: {args.model}")
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run PAML codeml for site-specific dN/dS analysis.",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""
+Requires PAML (codeml) to be installed and in PATH or specified via --paml_path.
+Supported models:
+  M0: one ratio for all sites
+  M1a (neutral): nearly neutral (0 < w0 < 1) and conserved (w1 = 1) sites
+  M2a (selection): adds a class of sites with w > 1 to M1a
+  M3 (discrete): discrete distribution of w values (k categories)
+  M7 (beta): beta distribution for w (0 < w < 1)
+  M8 (beta&w>1): M7 + a class of sites with w >= 1
+"""
+    )
+    parser.add_argument("--alignment", required=True, help="Path to the coding sequence alignment file (FASTA format).")
+    parser.add_argument("--tree", required=True, help="Path to the phylogenetic tree file (Newick format).")
+    parser.add_argument("--model", required=True, choices=["M0", "M1a", "M2a", "M3", "M7", "M8"],
+                        help="PAML model for site-specific analysis.")
+    parser.add_argument("--outfile_prefix", required=True, help="Prefix for PAML output files and the summary TSV.")
+    parser.add_argument("--paml_path", help="Optional path to the codeml executable. If not provided, assumes codeml is in system PATH.")
+    parser.add_argument("--verbose", action="store_true", help="Enable detailed PAML output (noisy = 9). Default is less verbose (noisy = 3).")
+    parser.add_argument("--cleandata", type=int, default=1, choices=[0, 1],
+                        help="PAML cleandata option: 1 to remove sites with gaps/ambiguities (default), 0 to keep.")
+    parser.add_argument("--num_site_categories", type=int, default=3,
+                        help="Number of site categories for M3 (discrete) model. Default: 3.")
+
+    args = parser.parse_args()
+
+    # --- Validate inputs ---
+    if not os.path.exists(args.alignment):
+        print(f"Error: Alignment file not found: {args.alignment}")
+        sys.exit(1)
+    if not os.path.exists(args.tree):
+        print(f"Error: Tree file not found: {args.tree}")
+        sys.exit(1)
+    
+    paml_exec = args.paml_path if args.paml_path else "codeml"
+    if shutil.which(paml_exec) is None:
+        print(f"Error: codeml executable not found at '{paml_exec}'. "
+              "Please ensure PAML is installed and in your PATH, or provide the correct path using --paml_path.")
+        sys.exit(1)
+
+    # --- Prepare input files ---
+    phylip_alignment_file = args.outfile_prefix + ".phy"
+    try:
+        AlignIO.convert(args.alignment, "fasta", phylip_alignment_file, "phylip-relaxed")
+        print(f"Converted FASTA alignment '{args.alignment}' to PHYLIP '{phylip_alignment_file}'.")
+    except Exception as e:
+        print(f"Error converting alignment to PHYLIP: {e}")
+        sys.exit(1)
+
+    # --- Setup PAML codeml ---
+    cml = codeml.Codeml()
+    cml.alignment = phylip_alignment_file
+    cml.tree = args.tree
+    cml.out_file = args.outfile_prefix + ".mlc" # Main results file
+    cml.working_dir = "." # Run in the current directory
+
+    try:
+        setup_codeml_options(cml, args)
+    except ValueError as e:
+        print(f"Error setting up PAML options: {e}")
+        sys.exit(1)
+    
+    # Print control file content for debugging if verbose
+    if args.verbose:
+        print("\n--- PAML Control File (codeml.ctl preview) ---")
+        # Temporarily set ctl_file to generate content for preview
+        original_ctl_file_option = cml.ctl_file # Store original if set
+        cml.ctl_file = "tmp_codeml_preview.ctl" 
+        cml.write_ctl_file()
+        with open(cml.ctl_file, "r") as f:
+            print(f.read())
+        os.remove(cml.ctl_file) # Clean up temp ctl
+        cml.ctl_file = original_ctl_file_option # Restore original ctl_file option
+        print("---------------------------------------------\n")
+
+
+    # --- Run codeml ---
+    print(f"Running PAML codeml with model {args.model}...")
+    try:
+        # Biopython's run method uses self._ctl_file attribute for the ctl filename.
+        # It defaults to "codeml.ctl". Let's ensure it's unique if multiple runs occur.
+        # However, cml.run() generates it based on working_dir and a standard name.
+        # The main concern is if cml.run() doesn't clean it up or if it conflicts.
+        # For now, assume Biopython handles ctl file naming within its execution context.
+        results = cml.run(command=paml_exec, verbose=args.verbose, parse=False) 
+        
+        print(f"codeml execution finished. Main output: {cml.out_file}")
+        
+        if not os.path.exists(cml.out_file):
+            print(f"Error: codeml main output file '{cml.out_file}' not found. Check for errors from codeml.")
+            rst_file_path = os.path.join(cml.working_dir, "rst")
+            if os.path.exists(rst_file_path):
+                with open(rst_file_path, "r") as rst_f:
+                    print(f"\n--- Content of '{rst_file_path}' file (may contain error details) ---")
+                    print(rst_f.read(2000)) 
+                    print("----------------------------------------------------------\n")
+            sys.exit(1)
+            
+        results = codeml.read(cml.out_file)
+        print("Successfully parsed codeml results.")
+
+    except CodemlError as e:
+        print(f"Error running PAML codeml: {e}")
+        if hasattr(e, 'stderr') and e.stderr:
+            print(f"codeml stderr:\n{e.stderr}")
+        
+        rst_file_path = os.path.join(cml.working_dir, "rst") 
+        rub_file_path = os.path.join(cml.working_dir, "rub")
+        if os.path.exists(rst_file_path):
+            with open(rst_file_path, "r") as rst_f:
+                print(f"\n--- Content of '{rst_file_path}' file (may contain error details) ---")
+                print(rst_f.read(2000))
+                print("----------------------------------------------------------\n")
+        if os.path.exists(rub_file_path):
+             with open(rub_file_path, "r") as rub_f:
+                print(f"\n--- Content of '{rub_file_path}' file (may contain error details) ---")
+                print(rub_f.read(2000))
+                print("----------------------------------------------------------\n")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred during codeml execution or parsing: {e}")
+        sys.exit(1)
+
+    # --- Parse and Summarize Output ---
+    print("\n--- PAML codeml Results Summary ---")
+    print(f"Model: {args.model}")
+    print(f"Log-likelihood (lnL): {results.get('lnL', 'N/A')}")
+
+    if 'parameters' in results:
+        params = results['parameters']
+        if 'kappa' in params:
+            print(f"kappa (ts/tv ratio): {params['kappa']:.4f}")
+        
+        ns_sites_key = str(cml.get_option("NSsites")) # e.g., "[0]", "[1]", "[2]"
+        
+        if ns_sites_key in results.get("NSsites", {}):
+            ns_params = results["NSsites"][ns_sites_key].get("parameters", {})
+            if "site classes" in ns_params: # For M1a, M2a, M3, M7, M8
+                print("Site classes:")
+                for sc in ns_params["site classes"]:
+                    proportion = sc.get('proportion', {}).get('value', 'N/A')
+                    # Omega value key can vary, sometimes 'omega', sometimes 'M0' (for the omega value itself)
+                    omega_val = sc.get('omega', {}).get('M0', sc.get('omega', 'N/A')) 
+                    if isinstance(omega_val, dict): # If omega is still a dict, try common keys
+                        omega_val = omega_val.get('M0', omega_val.get('omega', 'N/A'))
+
+                    print(f"  - Proportion: {proportion:.4f}, omega: {omega_val:.4f}")
+            elif 'omega' in ns_params: # For M0, if parsed into NSsites structure
+                 print(f"omega: {ns_params['omega']:.4f}")
+        elif args.model == "M0" and 'omega' in params: # M0 omega might be directly in parameters
+             print(f"omega: {params['omega']:.4f}")
+
+
+    site_analysis_file = args.outfile_prefix + "_site_analysis.tsv"
+    print(f"\nWriting site-specific analysis to: {site_analysis_file}")
+
+    with open(site_analysis_file, "w") as tsv_out:
+        header = ["Site", "AminoAcid", "dN_dS", "PosteriorProbability_PositiveSelection", "Note"]
+        tsv_out.write("\t".join(header) + "\n")
+        
+        beb_sites_data = []
+        all_sites_posterior_data = []
+        
+        ns_sites_key_str = str(cml.get_option("NSsites"))
+        
+        if ns_sites_key_str in results.get("NSsites", {}):
+            model_specific_params = results["NSsites"][ns_sites_key_str].get("parameters", {})
+
+            # Extract site class omegas
+            site_class_omegas = {}
+            if "site classes" in model_specific_params:
+                for i, sc_detail in enumerate(model_specific_params["site classes"]):
+                    omega_val = sc_detail.get('omega', {}).get('M0', sc_detail.get('omega', float('nan')))
+                    if isinstance(omega_val, dict): # If omega is still a dict, try common keys
+                        omega_val = omega_val.get('M0', omega_val.get('omega', float('nan')))
+                    site_class_omegas[i] = omega_val
+            
+            positive_selection_class_idx = -1
+            positive_selection_omega_value = float('nan')
+            for class_idx, omega_val in site_class_omegas.items():
+                if omega_val > 1.0:
+                    positive_selection_class_idx = class_idx
+                    positive_selection_omega_value = omega_val
+                    break # Assuming only one such class for M2a/M8
+
+            # For M2a and M8, BEB results are explicitly listed for positively selected sites
+            if args.model in ["M2a", "M8"] and "BEB positive sites" in model_specific_params:
+                for site_info in model_specific_params["BEB positive sites"]:
+                    # Structure: (site_index_1_based, amino_acid, prob_of_belonging_to_pos_sel_class, omega_of_pos_sel_class)
+                    # Or sometimes: (site_index_1_based, amino_acid, prob_class_k, omega_k) where class k has w > 1
+                    site_idx_1based, aa, prob_pos_sel_class = site_info[0], site_info[1], site_info[2]
+                    # The dN/dS value might be the specific omega for that class, or we use the identified positive_selection_omega_value
+                    dnds_val_beb = positive_selection_omega_value if not (len(site_info) > 3 and isinstance(site_info[3], float)) else site_info[3]
+                    
+                    note = ""
+                    if prob_pos_sel_class > 0.95: note = "Positive Selection (BEB > 0.95)"
+                    elif prob_pos_sel_class > 0.90: note = "Positive Selection (BEB > 0.90)"
+                    elif prob_pos_sel_class > 0.50: note = "Potential Positive Selection (BEB > 0.50)"
+                    
+                    beb_sites_data.append({
+                        "site": site_idx_1based, "aa": aa, "dnds": dnds_val_beb,
+                        "prob_positive": prob_pos_sel_class, "note": note
+                    })
+
+            # General site posterior probabilities (for all models with NSsites, if RateAncestor=1)
+            # Structure: (site_num_1_based, aa, [prob_class0, prob_class1, ...])
+            if "site_posterior_prob" in model_specific_params:
+                for site_info in model_specific_params["site_posterior_prob"]:
+                    site_idx_1based, aa = site_info[0], site_info[1]
+                    probs_per_class = site_info[2:] # This should be a list of probabilities
+
+                    # Determine the most probable class and its omega
+                    most_probable_class_idx = probs_per_class.index(max(probs_per_class))
+                    dnds_for_site = site_class_omegas.get(most_probable_class_idx, float('nan'))
+                    
+                    prob_positive_selection_class = 0.0
+                    note_for_site = ""
+                    if positive_selection_class_idx != -1 and positive_selection_class_idx < len(probs_per_class):
+                        prob_positive_selection_class = probs_per_class[positive_selection_class_idx]
+                        if prob_positive_selection_class > 0.95: note_for_site = "Positive Selection (BEB > 0.95)"
+                        elif prob_positive_selection_class > 0.90: note_for_site = "Positive Selection (BEB > 0.90)"
+                        elif prob_positive_selection_class > 0.50: note_for_site = "Potential Positive Selection (BEB > 0.50)"
+                    
+                    all_sites_posterior_data.append({
+                        "site": site_idx_1based, "aa": aa, "dnds": dnds_for_site,
+                        "prob_positive": prob_positive_selection_class, "note": note_for_site
+                    })
+
+        # Output logic:
+        # For M2a/M8, if beb_sites_data is populated, it's preferred as it's specific.
+        # Otherwise, or for other models, use all_sites_posterior_data if available.
+        
+        final_output_data = []
+        if args.model in ["M2a", "M8"] and beb_sites_data:
+            final_output_data = beb_sites_data
+        elif all_sites_posterior_data:
+            # For models not M2a/M8, or if BEB list was empty for M2a/M8,
+            # use the comprehensive list. The "prob_positive" will be 0 if no class has w > 1.
+            final_output_data = all_sites_posterior_data
+        
+        if final_output_data:
+            final_output_data.sort(key=lambda x: x['site'])
+            for site_entry in final_output_data:
+                 tsv_out.write(f"{site_entry['site']}\t{site_entry['aa']}\t"
+                               f"{site_entry['dnds']:.4f}\t{site_entry['prob_positive']:.4f}\t{site_entry['note']}\n")
+        else:
+            print("Warning: Could not extract detailed site-specific dN/dS data or BEB probabilities. "
+                  "The TSV file will be empty or incomplete. This might be expected for model M0, "
+                  "or indicates an issue with PAML output parsing or lack of positive selection findings.")
+            if args.model == "M0":
+                 tsv_out.write("Site-specific dN/dS is not applicable for model M0 (single ratio for all sites).\n")
+
+
+    # --- Cleanup temporary files ---
+    # phylip_alignment_file is <outfile_prefix>.phy, PAML output is <outfile_prefix>.mlc
+    # These are named based on user prefix, so generally should be kept.
+    # PAML also creates files like 2NG.dN, 2NG.dS, rst, rub in the working_dir.
+    # Users might want to inspect these. We will not delete them by default.
+    
+    print(f"\nScript finished. Check '{cml.out_file}' and '{site_analysis_file}' for results.")
+    print(f"Other PAML output files (e.g., rst, rub, 2NG.dN, 2NG.dS) may also be present in '{cml.working_dir}'.")
+
+if __name__ == "__main__":
+    main()

--- a/pylib/scripts/viral_tools/tests/test_calculate_nucleotide_diversity.py
+++ b/pylib/scripts/viral_tools/tests/test_calculate_nucleotide_diversity.py
@@ -1,0 +1,122 @@
+import unittest
+import subprocess
+import os
+import tempfile
+
+# Path to the script to be tested
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "..", "calculate_nucleotide_diversity.py")
+
+class TestCalculateNucleotideDiversity(unittest.TestCase):
+
+    def run_script(self, fasta_content=None, file_path=None):
+        """Helper method to run the script and return its output."""
+        if fasta_content is not None:
+            with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".fasta") as tmp_fasta:
+                tmp_fasta.write(fasta_content)
+                script_args = ["python3", SCRIPT_PATH, tmp_fasta.name]
+                temp_file_name = tmp_fasta.name
+        elif file_path is not None:
+            script_args = ["python3", SCRIPT_PATH, file_path]
+            temp_file_name = None # No temporary file created by this helper in this case
+        else:
+            raise ValueError("Either fasta_content or file_path must be provided")
+
+        process = subprocess.run(script_args, capture_output=True, text=True)
+        
+        if temp_file_name and fasta_content is not None: # Only delete if this helper created it
+            os.remove(temp_file_name)
+            
+        return process
+
+    def test_valid_alignment(self):
+        """Test with a valid FASTA alignment."""
+        fasta_content = """>Seq1
+ATGC
+>Seq2
+ATGT
+>Seq3
+AGGC
+"""
+        # Expected pi calculation:
+        # Seq1: ATGC
+        # Seq2: ATGT
+        # Seq3: AGGC
+        # Alignment length = 4
+        # Pairs:
+        # (Seq1, Seq2): diff = 1 (G vs T at pos 3)
+        # (Seq1, Seq3): diff = 1 (T vs G at pos 1)
+        # (Seq2, Seq3): diff = 2 (T vs G at pos 1, T vs C at pos 3)
+        # Sum of diffs = 1 + 1 + 2 = 4
+        # Number of sequences (n) = 3
+        # Number of pairs = 3 * (3-1) / 2 = 3
+        # pi = (Sum of diffs) / (Number of pairs) / (Alignment length)
+        # pi = 4 / 3 / 4 = 1/3 = 0.333333...
+        expected_pi_value = 1/3
+        
+        process = self.run_script(fasta_content=fasta_content)
+        
+        self.assertEqual(process.returncode, 0, f"Script failed with error: {process.stderr}")
+        self.assertIn("Nucleotide diversity (pi):", process.stdout)
+        
+        # Extract pi value from output
+        output_pi_str = None
+        for line in process.stdout.splitlines():
+            if "Nucleotide diversity (pi):" in line:
+                output_pi_str = line.split(":")[1].strip()
+                break
+        
+        self.assertIsNotNone(output_pi_str, "Pi value not found in script output.")
+        try:
+            output_pi_value = float(output_pi_str)
+        except ValueError:
+            self.fail(f"Could not convert pi value '{output_pi_str}' to float.")
+            
+        self.assertAlmostEqual(output_pi_value, expected_pi_value, places=5, 
+                               msg=f"Expected pi {expected_pi_value}, got {output_pi_value}")
+
+    def test_unaligned_sequences(self):
+        """Test with unaligned sequences (different lengths)."""
+        fasta_content = """>Seq1
+ATGC
+>Seq2
+ATGCA
+>Seq3
+AGGC
+"""
+        process = self.run_script(fasta_content=fasta_content)
+        self.assertNotEqual(process.returncode, 0, "Script should exit with an error for unaligned sequences.")
+        self.assertIn("Error: Sequences in the FASTA file are not all of the same length.", process.stdout, # Script prints to stdout for now
+                      "Error message for unaligned sequences not found.")
+
+    def test_empty_file(self):
+        """Test with an empty FASTA file."""
+        fasta_content = ""
+        process = self.run_script(fasta_content=fasta_content)
+        # The script might exit with 0 if no sequences are found but prints a message.
+        # Or it might exit with non-zero. Let's check for the message.
+        self.assertIn("No sequences found in the FASTA file.", process.stdout,
+                      "Error message for empty file not found.")
+
+    def test_single_sequence(self):
+        """Test with a FASTA file containing only one sequence."""
+        fasta_content = """>Seq1
+ATGCGTAGCAT
+"""
+        process = self.run_script(fasta_content=fasta_content)
+        self.assertIn("Nucleotide diversity calculation requires at least two sequences.", process.stdout,
+                      "Error message for single sequence not found.")
+
+    def test_file_not_found(self):
+        """Test with a non-existent file path."""
+        non_existent_file = "non_existent_file.fasta"
+        # Ensure the file does not exist before running the test
+        if os.path.exists(non_existent_file):
+            os.remove(non_existent_file)
+            
+        process = self.run_script(file_path=non_existent_file)
+        self.assertNotEqual(process.returncode, 0, "Script should exit with an error for file not found.")
+        self.assertIn(f"Error: File not found at {non_existent_file}", process.stdout, # Script prints to stdout for now
+                      "Error message for file not found not found.")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pylib/scripts/viral_tools/tests/test_calculate_site_specific_ds_dn.py
+++ b/pylib/scripts/viral_tools/tests/test_calculate_site_specific_ds_dn.py
@@ -1,0 +1,215 @@
+import unittest
+import subprocess
+import os
+import shutil
+import tempfile
+import sys
+
+# Path to the script to be tested
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "..", "calculate_site_specific_ds_dn.py")
+CODEML_AVAILABLE = shutil.which("codeml") is not None
+
+# Example FASTA content
+FASTA_CONTENT = """>Seq1
+ATGCGTAGCATT
+>Seq2
+ATGCGTACCATT
+>Seq3
+ATGCGTTCGATT
+""" # 12 bases = 4 codons
+
+# Example Newick tree content
+NEWICK_CONTENT = "(Seq1:0.1,Seq2:0.1,Seq3:0.1);"
+
+class TestCalculateSiteSpecificDsDn(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir_obj = tempfile.TemporaryDirectory()
+        self.temp_dir_path = self.temp_dir_obj.name
+
+        self.alignment_file = os.path.join(self.temp_dir_path, "test_alignment.fasta")
+        with open(self.alignment_file, "w") as f:
+            f.write(FASTA_CONTENT)
+
+        self.tree_file = os.path.join(self.temp_dir_path, "test_tree.nwk")
+        with open(self.tree_file, "w") as f:
+            f.write(NEWICK_CONTENT)
+            
+        # Create a dummy non-executable file for testing codeml path failure
+        self.dummy_non_exec_codeml = os.path.join(self.temp_dir_path, "dummy_codeml")
+        with open(self.dummy_non_exec_codeml, "w") as f:
+            f.write("#!/bin/sh\nexit 1") # Not executable by default
+        # os.chmod(self.dummy_non_exec_codeml, 0o644) # Ensure it's not executable
+
+    def tearDown(self):
+        self.temp_dir_obj.cleanup()
+
+    def _run_script(self, args_list):
+        """Helper method to run the script and return its output."""
+        full_args = [sys.executable, SCRIPT_PATH] + args_list # Use sys.executable for python interpreter
+        return subprocess.run(full_args, capture_output=True, text=True, cwd=self.temp_dir_path)
+
+    @unittest.skipIf(CODEML_AVAILABLE, "codeml is available, skipping test for its absence")
+    def test_codeml_not_found_graceful_exit_dummy_path(self):
+        """Test graceful exit if codeml is not found at the specified dummy path."""
+        # This test runs if shutil.which("codeml") is None.
+        # We provide a path to a non-executable file.
+        args = [
+            "--alignment", self.alignment_file,
+            "--tree", self.tree_file,
+            "--model", "M0",
+            "--outfile_prefix", "test_run_m0_codeml_fail",
+            "--paml_path", self.dummy_non_exec_codeml 
+        ]
+        process = self._run_script(args)
+        self.assertNotEqual(process.returncode, 0, "Script should exit with non-zero status if dummy codeml is not executable.")
+        self.assertIn(f"Error: codeml executable not found at '{self.dummy_non_exec_codeml}'", process.stdout)
+
+    # A variation for when codeml is not in PATH and --paml_path is not given
+    @unittest.skipIf(CODEML_AVAILABLE, "codeml is available, skipping test for its absence from PATH")
+    def test_codeml_not_in_path_graceful_exit(self):
+        """Test graceful exit if codeml is not in PATH and --paml_path is not given."""
+        args = [
+            "--alignment", self.alignment_file,
+            "--tree", self.tree_file,
+            "--model", "M0",
+            "--outfile_prefix", "test_run_m0_codeml_path_fail"
+            # No --paml_path here
+        ]
+        process = self._run_script(args)
+        self.assertNotEqual(process.returncode, 0, "Script should exit with non-zero status if codeml is not in PATH.")
+        # shutil.which uses os.environ.get("PATH"), so this should trigger the "not found"
+        self.assertIn("Error: codeml executable not found at 'codeml'.", process.stdout)
+
+
+    def test_input_file_not_found(self):
+        """Test script behavior when input files are not found."""
+        non_existent_alignment = os.path.join(self.temp_dir_path, "no_align.fasta")
+        non_existent_tree = os.path.join(self.temp_dir_path, "no_tree.nwk")
+
+        # Test non-existent alignment
+        args_no_align = [
+            "--alignment", non_existent_alignment,
+            "--tree", self.tree_file,
+            "--model", "M0",
+            "--outfile_prefix", "test_no_align"
+        ]
+        process_no_align = self._run_script(args_no_align)
+        self.assertNotEqual(process_no_align.returncode, 0)
+        self.assertIn(f"Error: Alignment file not found: {non_existent_alignment}", process_no_align.stdout)
+
+        # Test non-existent tree
+        args_no_tree = [
+            "--alignment", self.alignment_file,
+            "--tree", non_existent_tree,
+            "--model", "M0",
+            "--outfile_prefix", "test_no_tree"
+        ]
+        process_no_tree = self._run_script(args_no_tree)
+        self.assertNotEqual(process_no_tree.returncode, 0)
+        self.assertIn(f"Error: Tree file not found: {non_existent_tree}", process_no_tree.stdout)
+
+    def test_invalid_model_name(self):
+        """Test script behavior with an invalid model name."""
+        args = [
+            "--alignment", self.alignment_file,
+            "--tree", self.tree_file,
+            "--model", "M99", # Invalid model
+            "--outfile_prefix", "test_invalid_model"
+        ]
+        process = self._run_script(args)
+        self.assertNotEqual(process.returncode, 0)
+        # argparse error messages go to stderr
+        self.assertIn("invalid choice: 'M99'", process.stderr)
+
+    @unittest.skipUnless(CODEML_AVAILABLE, "codeml not found in PATH, skipping codeml execution test.")
+    def test_successful_run_M0(self):
+        """Test a successful run with model M0."""
+        prefix = "m0_success"
+        outfile_prefix_path = os.path.join(self.temp_dir_path, prefix)
+        args = [
+            "--alignment", self.alignment_file,
+            "--tree", self.tree_file,
+            "--model", "M0",
+            "--outfile_prefix", outfile_prefix_path,
+            "--cleandata", "1" # Ensure it runs with this common option
+        ]
+        process = self._run_script(args)
+        
+        # PAML can print warnings to stderr even on success, so check stdout for key success messages
+        # and primarily rely on return code and file existence.
+        if process.returncode != 0:
+            print(f"M0 run STDOUT:\n{process.stdout}")
+            print(f"M0 run STDERR:\n{process.stderr}")
+        self.assertEqual(process.returncode, 0, "Script failed for M0 model.")
+
+        mlc_file = outfile_prefix_path + ".mlc"
+        tsv_file = outfile_prefix_path + "_site_analysis.tsv"
+        self.assertTrue(os.path.exists(mlc_file), f"PAML output file {mlc_file} not created.")
+        self.assertTrue(os.path.exists(tsv_file), f"Summary TSV file {tsv_file} not created.")
+
+        with open(tsv_file, "r") as f:
+            lines = f.readlines()
+        
+        self.assertTrue(len(lines) >= 1, "TSV file is empty.")
+        expected_header = "Site\tAminoAcid\tdN_dS\tPosteriorProbability_PositiveSelection\tNote\n"
+        self.assertEqual(lines[0], expected_header, "TSV header is incorrect.")
+        
+        # For M0, site-specific dN/dS is not really applicable, the script writes a note.
+        # Let's check that.
+        if len(lines) > 1:
+             self.assertIn("Site-specific dN/dS is not applicable for model M0", lines[1])
+
+
+    @unittest.skipUnless(CODEML_AVAILABLE, "codeml not found in PATH, skipping codeml execution test.")
+    def test_successful_run_M8_beb(self):
+        """Test a successful run with model M8 for BEB results."""
+        prefix = "m8_beb_success"
+        outfile_prefix_path = os.path.join(self.temp_dir_path, prefix)
+        args = [
+            "--alignment", self.alignment_file,
+            "--tree", self.tree_file,
+            "--model", "M8",
+            "--outfile_prefix", outfile_prefix_path,
+            "--cleandata", "1"
+        ]
+        process = self._run_script(args)
+
+        if process.returncode != 0:
+            print(f"M8 run STDOUT:\n{process.stdout}")
+            print(f"M8 run STDERR:\n{process.stderr}")
+        self.assertEqual(process.returncode, 0, "Script failed for M8 model.")
+
+        mlc_file = outfile_prefix_path + ".mlc"
+        tsv_file = outfile_prefix_path + "_site_analysis.tsv"
+        self.assertTrue(os.path.exists(mlc_file), f"PAML output file {mlc_file} not created.")
+        self.assertTrue(os.path.exists(tsv_file), f"Summary TSV file {tsv_file} not created.")
+
+        with open(tsv_file, "r") as f:
+            lines = f.readlines()
+        
+        self.assertTrue(len(lines) >= 1, "TSV file is empty.")
+        expected_header = "Site\tAminoAcid\tdN_dS\tPosteriorProbability_PositiveSelection\tNote\n"
+        self.assertEqual(lines[0], expected_header, "TSV header is incorrect for M8.")
+        
+        num_codons = 4 # From FASTA_CONTENT
+        # Expect header + num_codons lines
+        self.assertEqual(len(lines), num_codons + 1, f"TSV file should have {num_codons+1} lines (header + data).")
+
+        # Check that data lines are populated for M8
+        for i in range(1, len(lines)):
+            parts = lines[i].strip().split('\t')
+            self.assertEqual(len(parts), 5, f"TSV data line {i} does not have 5 columns.")
+            self.assertTrue(parts[0].isdigit(), f"Site column in line {i} is not a digit.")
+            self.assertTrue(len(parts[1]) > 0, f"AminoAcid column in line {i} is empty.") # AA can be X if cleandata=0
+            try:
+                float(parts[2]) # dN_dS
+                float(parts[3]) # PosteriorProbability_PositiveSelection
+            except ValueError:
+                self.fail(f"dN_dS or PosteriorProbability in line {i} is not a float: {lines[i]}")
+            # Note column can be empty if no positive selection detected with high probability
+            # self.assertTrue(len(parts[4]) > 0, f"Note column in line {i} is empty.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/virus_genomics_guide.md
+++ b/virus_genomics_guide.md
@@ -12,5 +12,32 @@
 ## Tools and Resources
 (Placeholder for content: List relevant EvolCat-Python scripts that can be used for viral genomics. Also, list key external databases, software, and web resources for viral genomics research.)
 
+### Site-Specific dN/dS Analysis (`calculate_site_specific_ds_dn.py`)
+
+This script serves as a Python wrapper for the `codeml` program from the PAML (Phylogenetic Analysis by Maximum Likelihood) package. Its primary purpose is to automate and simplify the process of identifying natural selection acting at individual codon sites within a set of aligned coding sequences.
+
+The dN/dS ratio (often denoted as ω or omega) is a key metric in these analyses:
+*   **dN/dS > 1**: Suggests positive (Darwinian) selection, where mutations leading to amino acid changes are favored.
+*   **dN/dS < 1**: Indicates purifying (negative) selection, where mutations changing amino acids are deleterious and removed.
+*   **dN/dS = 1**: Points towards neutral evolution, where amino acid changes have no selective advantage or disadvantage.
+
+**Main Inputs:**
+*   **Coding Sequence Alignment (FASTA format):** An alignment of homologous coding sequences (e.g., a specific gene from different viral strains). Sequences must be a multiple of three nucleotides.
+*   **Phylogenetic Tree (Newick format):** A tree representing the evolutionary relationships among the sequences in the alignment. Branch lengths are important.
+*   **PAML Model:** The specific site model to be used by `codeml` (e.g., M0, M1a, M2a, M3, M7, M8). Different models allow for different assumptions about the distribution of dN/dS ratios across sites.
+
+**Primary Output:**
+The script generates several output files prefixed by a user-defined string. The most important for site-specific analysis is a tab-separated values (TSV) file named `<outfile_prefix>_site_analysis.tsv`. This file contains:
+*   Site number (codon position in the alignment).
+*   The amino acid present at that site in a reference sequence (if applicable from PAML output).
+*   The estimated dN/dS ratio for that site (or the dN/dS class the site is assigned to, depending on the model).
+*   Posterior probabilities from Bayes Empirical Bayes (BEB) analysis, which are crucial for identifying sites under positive selection with statistical confidence (especially relevant for models like M2a and M8).
+*   A "Note" column highlighting sites with significant evidence of positive selection (e.g., BEB probability > 0.95).
+
+**PAML Dependency:**
+**Crucially, this script requires PAML (specifically the `codeml` executable) to be installed on your system.** `codeml` must either be accessible in your system's PATH environment variable, or its direct path must be provided to the script using the `--paml_path` argument.
+
+The `calculate_site_specific_ds_dn.py` script automates the creation of `codeml` control files, executes `codeml`, and parses its often complex output files into a more structured and user-friendly TSV format, facilitating the identification of codons potentially under selection.
+
 ## Example Workflow: Analyzing a Viral Dataset
 (Placeholder for content: Outline a hypothetical step-by-step workflow for analyzing a small viral dataset, from sequence retrieval to diversity calculation and phylogenetic tree construction, mentioning which tools (EvolCat-Python or external) would be used at each step.)

--- a/virus_genomics_guide.md
+++ b/virus_genomics_guide.md
@@ -1,0 +1,16 @@
+# Guide to Virus Genomics, Diversity, and Analysis
+
+## Introduction to Virus Genomics
+(Placeholder for content: Briefly explain what virus genomics is, its importance, and key characteristics of viral genomes, e.g., size, mutation rates, RNA vs DNA.)
+
+## Measuring Viral Diversity
+(Placeholder for content: Discuss common metrics and methods used to quantify viral diversity, e.g., nucleotide diversity, haplotype analysis, quasispecies.)
+
+## Phylogenetic Analysis of Viruses
+(Placeholder for content: Explain how phylogenetic methods are applied to viruses, what insights can be gained, e.g., tracking outbreaks, understanding evolutionary relationships. Mention specific EvolCat-Python scripts or external tools if applicable.)
+
+## Tools and Resources
+(Placeholder for content: List relevant EvolCat-Python scripts that can be used for viral genomics. Also, list key external databases, software, and web resources for viral genomics research.)
+
+## Example Workflow: Analyzing a Viral Dataset
+(Placeholder for content: Outline a hypothetical step-by-step workflow for analyzing a small viral dataset, from sequence retrieval to diversity calculation and phylogenetic tree construction, mentioning which tools (EvolCat-Python or external) would be used at each step.)


### PR DESCRIPTION
This commit introduces a new section on virus genomics, diversity, and analysis.

Key changes include:
- A new markdown file `virus_genomics_guide.md` providing an overview of viral genomics concepts, tools, and example workflows.
- A new script `pylib/scripts/viral_tools/calculate_nucleotide_diversity.py` to calculate nucleotide diversity (pi) from a FASTA alignment. This script serves as an initial code example for viral analysis.
- Unit tests for `calculate_nucleotide_diversity.py` located in `pylib/scripts/viral_tools/tests/`.
- An update to `README.md` to include a link to the new `virus_genomics_guide.md` under a new subsection "E. Special Topic: Virus Genomics, Diversity, and Analysis" in the "Workflow Examples".

And introduces a new script `calculate_site_specific_ds_dn.py`
located in `pylib/scripts/viral_tools/`. This script acts as a wrapper
around PAML's `codeml` program to perform site-specific analysis of
synonymous (dS) and non-synonymous (dN) substitution rates.

Key features:
- Takes a coding sequence alignment (FASTA) and a phylogenetic tree (Newick)
  as input.
- Supports various PAML models for site-specific analysis (M0, M1a, M2a, M3, M7, M8).
- Automates the generation of PAML control files and execution of `codeml`.
- Parses `codeml` output to extract log-likelihood, model parameters, and
  Bayes Empirical Bayes (BEB) probabilities for sites under positive selection.
- Generates a user-friendly TSV summary of site-specific results.
- Requires PAML (`codeml` executable) to be installed.

This commit also includes:
- Unit tests for `calculate_site_specific_ds_dn.py` in
  `pylib/scripts/viral_tools/tests/`, which conditionally run `codeml`.
- Updates to `virus_genomics_guide.md` to document the new script,
  its usage, and the PAML dependency.