### PR TITLE
Add analyze_vcf.py script for VCF filtering

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1079,3 +1079,46 @@ A summary message indicating the total number of motifs found and sequences proc
 - The script converts the IUPAC motif string to a regular expression for searching.
 - Searches are case-insensitive.
 - The script will report all non-overlapping matches.
+
+---
+
+## `pylib/scripts/analyze_vcf.py`
+
+Filters a VCF (Variant Call Format) file based on variant quality (QUAL) and read depth (DP) criteria.
+It can output a new filtered VCF file and/or a tab-delimited summary report of the variants that pass the filters.
+This script uses internal logic for VCF parsing and does not require external libraries like PyVCF.
+
+**Usage:**
+```bash
+python3 pylib/scripts/analyze_vcf.py -i <input_vcf_file> [-o <output_vcf_file>] [-r <summary_report_file>] [-q <min_qual>] [-d <min_dp>]
+```
+
+**Arguments:**
+-   `-i, --vcf_file <input_vcf_file>`: (Required) Path to the input VCF file.
+-   `-o, --output_vcf <output_vcf_file>`: (Optional) Path to the output filtered VCF file. If not provided, no filtered VCF will be written.
+-   `-r, --summary_report <summary_report_file>`: (Optional) Path to the output summary report file (tab-delimited). If not provided, no summary report will be written.
+        The report will contain the columns: `CHROM POS ID REF ALT QUAL DP`.
+-   `-q, --min_qual <float>`: (Optional) Minimum variant quality score (QUAL) to keep a record. Default: `30.0`.
+-   `-d, --min_dp <integer>`: (Optional) Minimum total read depth (DP field in INFO) to keep a record. Default: `10`.
+
+**Important:**
+- At least one of `--output_vcf` or `--summary_report` must be specified.
+- The script expects the `DP` value to be present in the INFO field of VCF records.
+
+**Examples:**
+
+1.  **Filter VCF and get both filtered VCF and summary report:**
+    ```bash
+    python3 pylib/scripts/analyze_vcf.py -i variants.vcf -o filtered_variants.vcf -r report.tsv -q 50 -d 20
+    ```
+
+2.  **Filter VCF and get only the filtered VCF file, using default QUAL and DP:**
+    ```bash
+    python3 pylib/scripts/analyze_vcf.py -i variants.vcf -o filtered_variants.vcf
+    ```
+
+3.  **Filter VCF and get only the summary report with custom QUAL:**
+    ```bash
+    python3 pylib/scripts/analyze_vcf.py -i variants.vcf -r report.tsv -q 75
+    ```
+---

--- a/docs/virus_genomics_guide.md
+++ b/docs/virus_genomics_guide.md
@@ -357,37 +357,21 @@ def analyze_viral_genome_details(fasta_file):
 ### Variant Calling and Analysis
 1.  **Alignment:** Align reads to a reference (Bowtie2, BWA, Minimap2) -> SAM/BAM.
 2.  **Variant Calling:** Use bcftools, LoFreq, iVar -> VCF.
-3.  **Python for VCF Analysis (PyVCF):**
+3.  **VCF Analysis with `analyze_vcf.py` (EvolCat-Python):**
+    Once a VCF file is generated, the EvolCat-Python script `pylib/scripts/analyze_vcf.py` can be used for basic filtering and conversion. This script allows users to filter variants based on minimum quality (QUAL) scores and read depth (DP) information directly from the command line. It can produce a new, filtered VCF file or a tab-delimited summary report of the variants that pass the specified criteria. The script uses internal logic to parse VCF files.
 
-```python
-import vcf # Ensure: pip install pyvcf
-
-def analyze_vcf_details(vcf_filepath, min_qual=30, min_dp=10):
-    print(f"\n--- Analyzing VCF file: {vcf_filepath} ---")
-    try:
-        vcf_reader = vcf.Reader(open(vcf_filepath, 'r'))
-        count = 0
-        for record in vcf_reader:
-            qual_pass = record.QUAL is not None and record.QUAL >= min_qual
-            
-            dp_pass = False
-            depth_info = "N/A"
-            if 'DP' in record.INFO and isinstance(record.INFO.get('DP'), (int, float)) and record.INFO['DP'] >= min_dp:
-                dp_pass = True
-                depth_info = f"INFO DP: {record.INFO['DP']}"
-            elif hasattr(record, 'samples') and record.samples and 'DP' in record.samples[0].data._fields and \
-                 isinstance(record.samples[0]['DP'], (int,float)) and record.samples[0]['DP'] >= min_dp:
-                dp_pass = True
-                depth_info = f"Sample {record.samples[0].sample} DP: {record.samples[0]['DP']}"
-            
-            if qual_pass and dp_pass:
-                count += 1
-                print(f"  Variant at {record.CHROM}:{record.POS} {record.REF} -> {record.ALT}")
-                print(f"    Quality: {record.QUAL}, Depth: {depth_info}")
-        print(f"\nFound {count} variants passing filters (QUAL>={min_qual}, DP>={min_dp}).")
-    except Exception as e:
-        print(f"Error processing VCF file {vcf_filepath}: {e}")
-```
+    **Example usage:**
+    ```bash
+    # Filter input.vcf, keeping variants with QUAL >= 50 and DP >= 20
+    # Output a filtered VCF and a summary report
+    python pylib/scripts/analyze_vcf.py \\
+        --vcf_file input.vcf \\
+        --min_qual 50 \\
+        --min_dp 20 \\
+        --output_vcf filtered_variants.vcf \\
+        --summary_report variant_summary.tsv
+    ```
+    This script helps in narrowing down candidate variants for further investigation by removing lower-confidence calls. For more advanced VCF manipulation or annotation, users might explore libraries like `cyvcf2` or tools like `bcftools` further.
 
 ### Multiple Sequence Alignment MSA with Python Wrapper
 
@@ -567,6 +551,7 @@ This section highlights specific EvolCat-Python scripts relevant to viral genomi
 *   **`pylib/scripts/nogaps.py`**: Removes columns from an MSA that consist entirely or predominantly of gaps.
 *   **`pylib/scripts/fas2phy.py`**: Converts sequence alignments from FASTA to PHYLIP format.
 *   **(Conceptual) `pylib/scripts/extract_region.py`**: For extracting specific genomic regions (functionality may vary).
+*   **`pylib/scripts/analyze_vcf.py`**: Filters VCF (Variant Call Format) files based on quality (QUAL) and depth (DP) criteria. It can output a new filtered VCF file or a tab-delimited summary report of passing variants.
 
 ### Key External Databases and Resources Recap
 

--- a/pylib/scripts/analyze_vcf.py
+++ b/pylib/scripts/analyze_vcf.py
@@ -1,0 +1,124 @@
+import argparse
+import sys
+
+def parse_info(info_str):
+    """Parses the INFO field of a VCF record and returns a dictionary."""
+    info_dict = {}
+    for item in info_str.split(';'):
+        if '=' in item:
+            key, value = item.split('=', 1)
+            info_dict[key] = value
+        else:
+            info_dict[item] = True # For flags
+    return info_dict
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze and filter VCF files.")
+    parser.add_argument("-i", "--vcf_file", required=True, help="Path to the input VCF file.")
+    parser.add_argument("-o", "--output_vcf", help="Path to the output filtered VCF file.")
+    parser.add_argument("-r", "--summary_report", help="Path to the output summary report file (tab-delimited).")
+    parser.add_argument("-q", "--min_qual", type=float, default=30.0, help="Minimum variant quality score to keep a record.")
+    parser.add_argument("-d", "--min_dp", type=int, default=10, help="Minimum total read depth (DP field in INFO) to keep a record.")
+
+    args = parser.parse_args()
+
+    if not args.output_vcf and not args.summary_report:
+        parser.error("At least one of --output_vcf or --summary_report must be specified.")
+
+    print(f"Processing VCF file: {args.vcf_file}")
+
+    header_lines = []
+    filtered_data_lines = []
+    report_data = []
+
+    try:
+        with open(args.vcf_file, 'r') as vcf_reader:
+            for line in vcf_reader:
+                line = line.strip()
+                if not line:
+                    continue
+                if line.startswith("##"):
+                    header_lines.append(line)
+                    continue
+                if line.startswith("#CHROM"):
+                    header_lines.append(line) # VCF header line
+                    report_header = line[1:].split("\t")[:5] + ["QUAL", "DP"] # CHROM, POS, ID, REF, ALT, QUAL, DP
+                    continue
+
+                fields = line.split('\t')
+                if len(fields) < 8:
+                    print(f"Warning: Skipping malformed VCF line: {line}", file=sys.stderr)
+                    continue
+
+                chrom, pos, record_id, ref, alt, qual_str, _, info_str = fields[:8]
+                
+                try:
+                    qual = float(qual_str) if qual_str != '.' else -1.0
+                except ValueError:
+                    print(f"Warning: Skipping record with invalid QUAL value {qual_str} at {chrom}:{pos}", file=sys.stderr)
+                    continue
+
+                info_dict = parse_info(info_str)
+                dp_value_str = info_dict.get('DP')
+                dp_value = -1
+                if dp_value_str is not None:
+                    try:
+                        dp_value = int(dp_value_str)
+                    except ValueError:
+                        print(f"Warning: Skipping record with invalid DP value {dp_value_str} at {chrom}:{pos}", file=sys.stderr)
+                        # Continue to QUAL check, maybe it passes QUAL and we still want to report it if only DP is bad?
+                        # For now, let's treat invalid DP as not passing the DP filter.
+                        dp_value = -1
+
+
+                passes_qual = qual >= args.min_qual
+                passes_dp = dp_value >= args.min_dp
+                
+                if passes_qual and passes_dp:
+                    filtered_data_lines.append(line)
+                    report_data.append({
+                        "CHROM": chrom,
+                        "POS": pos,
+                        "ID": record_id,
+                        "REF": ref,
+                        "ALT": alt, # ALT is already a string, potentially comma-separated
+                        "QUAL": f"{qual:.1f}" if qual != -1.0 else ".", # Format QUAL to one decimal place for consistency
+                        "DP": str(dp_value) if dp_value != -1 else "."
+                    })
+
+    except FileNotFoundError:
+        print(f"Error: Input VCF file not found at {args.vcf_file}", file=sys.stderr)
+        exit(1)
+    except Exception as e:
+        print(f"Error processing VCF file: {e}", file=sys.stderr)
+        exit(1)
+
+    if args.output_vcf:
+        try:
+            with open(args.output_vcf, 'w') as vcf_writer:
+                for header_line in header_lines:
+                    vcf_writer.write(header_line + "\n")
+                for data_line in filtered_data_lines:
+                    vcf_writer.write(data_line + "\n")
+        except Exception as e:
+            print(f"Error writing filtered VCF to {args.output_vcf}: {e}", file=sys.stderr)
+
+    if args.summary_report:
+        try:
+            with open(args.summary_report, 'w') as report_file:
+                # Write header, ensure it matches the expected format
+                report_file.write("CHROM\tPOS\tID\tREF\tALT\tQUAL\tDP\n")
+                # Write data
+                for row in report_data:
+                    report_file.write(f"{row['CHROM']}\t{row['POS']}\t{row['ID']}\t{row['REF']}\t{row['ALT']}\t{row['QUAL']}\t{row['DP']}\n")
+        except Exception as e:
+            print(f"Error writing summary report to {args.summary_report}: {e}", file=sys.stderr)
+
+    print("Filtering complete.")
+    if args.output_vcf:
+        print(f"Filtered VCF written to {args.output_vcf}")
+    if args.summary_report:
+        print(f"Summary report written to {args.summary_report}")
+
+if __name__ == '__main__':
+    main()

--- a/test_data/expected_filtered_q45_d20.vcf
+++ b/test_data/expected_filtered_q45_d20.vcf
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+##FILTER=<ID=lowqual,Description="Low quality">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	100	rs1	A	T	50	PASS	DP=30;AF=0.5
+chr1	400	rs4	T	C	60	PASS	DP=50;AF=0.8
+chr1	500	rs5	A	G,T	70	PASS	DP=40;AF=0.3,0.2
+chr2	300	rs8	C	T	80	PASS	DP=60;AF=0.7

--- a/test_data/expected_report_q30_d35.tsv
+++ b/test_data/expected_report_q30_d35.tsv
@@ -1,0 +1,4 @@
+CHROM	POS	ID	REF	ALT	QUAL	DP
+chr1	400	rs4	T	C	60.0	50
+chr1	500	rs5	A	G,T	70.0	40
+chr2	300	rs8	C	T	80.0	60

--- a/test_data/input.vcf
+++ b/test_data/input.vcf
@@ -1,0 +1,13 @@
+##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+##FILTER=<ID=lowqual,Description="Low quality">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	100	rs1	A	T	50	PASS	DP=30;AF=0.5
+chr1	200	rs2	C	G	20	lowqual	DP=10;AF=0.1
+chr1	300	rs3	G	A	100	PASS	DP=5;AF=1.0
+chr1	400	rs4	T	C	60	PASS	DP=50;AF=0.8
+chr1	500	rs5	A	G,T	70	PASS	DP=40;AF=0.3,0.2
+chr2	100	rs6	T	A	40	PASS	DP=25
+chr2	200	rs7	G	C	10	lowqual	DP=80;AF=0.05
+chr2	300	rs8	C	T	80	PASS	DP=60;AF=0.7

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Define paths
+SCRIPT_PATH="pylib/scripts/analyze_vcf.py"
+INPUT_VCF="test_data/input.vcf"
+
+# Test Case 1: Filtered VCF
+OUTPUT_FILTERED_VCF_ACTUAL="test_data/actual_filtered_q45_d20.vcf"
+EXPECTED_FILTERED_VCF="test_data/expected_filtered_q45_d20.vcf"
+MIN_QUAL_1=45
+MIN_DP_1=20
+
+# Test Case 2: Summary Report
+OUTPUT_SUMMARY_REPORT_ACTUAL="test_data/actual_report_q30_d35.tsv"
+EXPECTED_SUMMARY_REPORT="test_data/expected_report_q30_d35.tsv"
+MIN_QUAL_2=30
+MIN_DP_2=35
+
+# Ensure the python script is available
+if [ ! -f "$SCRIPT_PATH" ]; then
+    echo "FAIL: Analysis script not found at $SCRIPT_PATH"
+    exit 1
+fi
+
+# Run Test Case 1
+echo "Running Test Case 1: Filtered VCF (QUAL >= $MIN_QUAL_1, DP >= $MIN_DP_1)"
+python3 "$SCRIPT_PATH" -i "$INPUT_VCF" -q "$MIN_QUAL_1" -d "$MIN_DP_1" -o "$OUTPUT_FILTERED_VCF_ACTUAL"
+if [ $? -ne 0 ]; then
+    echo "FAIL: Script execution failed for Test Case 1"
+    exit 1
+fi
+
+# Compare filtered VCF files
+diff_output_vcf=$(diff "$OUTPUT_FILTERED_VCF_ACTUAL" "$EXPECTED_FILTERED_VCF")
+if [ -z "$diff_output_vcf" ]; then
+    echo "PASS: Filtered VCF matches expected output."
+    TEST_1_PASSED=true
+else
+    echo "FAIL: Filtered VCF does not match expected output."
+    echo "Differences:"
+    echo "$diff_output_vcf"
+    TEST_1_PASSED=false
+fi
+
+# Run Test Case 2
+echo -e "\nRunning Test Case 2: Summary Report (QUAL >= $MIN_QUAL_2, DP >= $MIN_DP_2)"
+python3 "$SCRIPT_PATH" -i "$INPUT_VCF" -q "$MIN_QUAL_2" -d "$MIN_DP_2" -r "$OUTPUT_SUMMARY_REPORT_ACTUAL"
+if [ $? -ne 0 ]; then
+    echo "FAIL: Script execution failed for Test Case 2"
+    # Clean up Test Case 1 actual file before exiting
+    rm -f "$OUTPUT_FILTERED_VCF_ACTUAL"
+    exit 1
+fi
+
+# Compare summary report files
+diff_output_report=$(diff "$OUTPUT_SUMMARY_REPORT_ACTUAL" "$EXPECTED_SUMMARY_REPORT")
+if [ -z "$diff_output_report" ]; then
+    echo "PASS: Summary report matches expected output."
+    TEST_2_PASSED=true
+else
+    echo "FAIL: Summary report does not match expected output."
+    echo "Differences:"
+    echo "$diff_output_report"
+    TEST_2_PASSED=false
+fi
+
+# Clean up actual files
+echo -e "\nCleaning up actual output files..."
+rm -f "$OUTPUT_FILTERED_VCF_ACTUAL"
+rm -f "$OUTPUT_SUMMARY_REPORT_ACTUAL"
+echo "Cleanup complete."
+
+# Final result
+echo -e "\n----- Summary -----"
+if $TEST_1_PASSED; then
+    echo "Test Case 1 (Filtered VCF): PASS"
+else
+    echo "Test Case 1 (Filtered VCF): FAIL"
+fi
+
+if $TEST_2_PASSED; then
+    echo "Test Case 2 (Summary Report): PASS"
+else
+    echo "Test Case 2 (Summary Report): FAIL"
+fi
+
+if $TEST_1_PASSED && $TEST_2_PASSED; then
+    echo -e "\nAll tests passed!"
+    exit 0
+else
+    echo -e "\nSome tests failed."
+    exit 1
+fi


### PR DESCRIPTION
This commit introduces a new script, `pylib/scripts/analyze_vcf.py`, to facilitate basic filtering of VCF files. You can filter variants based on minimum quality (QUAL) and read depth (DP) criteria. The script can output a new filtered VCF file and/or a tab-delimited summary report.

Key changes include:
- Addition of `pylib/scripts/analyze_vcf.py`. Due to issues with PyVCF in the test environment, this script was implemented using manual VCF parsing.
- Creation of test data and a test runner (`test_runner.sh`) in the `test_data/` directory to verify the script's functionality.
- Updates to `docs/virus_genomics_guide.md` to describe the new script in the "Variant Calling and Analysis" section, replacing the previous PyVCF example.
- Addition of usage instructions and examples for `analyze_vcf.py` to `docs/USAGE.md`.

This script enhances the project's capabilities in handling VCF files, particularly within the context of viral genomics analysis.