### PR TITLE
Add Back to Top links to virology documents

### DIFF
--- a/docs/virus_biology_and_analysis/biotechnologies_in_virology_guide.md
+++ b/docs/virus_biology_and_analysis/biotechnologies_in_virology_guide.md
@@ -1,3 +1,4 @@
+<a name="top"></a>
 # Guide to Key Biotechnologies in Virology Research
 
 This guide provides an overview of several foundational and cutting-edge biotechnologies that have significantly advanced the field of virology. Understanding these techniques is crucial for interpreting virological data and appreciating the methods behind discoveries in virus evolution, pathogenesis, and the development of countermeasures. Much of the detailed text herein is adapted from a broader research report on virus evolution, focusing specifically on the methodologies.
@@ -24,6 +25,8 @@ Plasmids are not merely passive carriers; they serve as the fundamental enabling
 
 The progressive sophistication of plasmid technology mirrors the increasing ambition and complexity of questions addressed in viral research. The initial use of plasmids was primarily for simple cloning and amplification of DNA fragments (15). However, plasmid design has evolved to include highly engineered systems capable of precise gene delivery, regulated expression, and multi-component genetic manipulation within living cells and organisms (15). Examples include lentiviral vectors with bicistronic elements for co-expression of transgenes and markers, or those compatible with Gateway Technology for high-throughput cloning (15). This iterative refinement of a foundational biotechnology allows researchers to tackle more intricate biological problems, moving beyond simply understanding viral genes to actively repurposing viral mechanisms for therapeutic and preventative applications, often involving complex artificial recombination events.
 
+[Back to Top](#top)
+
 ## 2. Seminal Breakthroughs in Viral Reconstruction and Synthetic Biology
 
 ### 2.1. Synthetic Genomes: Eckard Wimmer's Poliovirus and the Era of De Novo Virus Synthesis
@@ -34,6 +37,8 @@ Wimmer's work provided the ultimate chemical proof that the deciphered polioviru
 This seminal work fundamentally changed the conceptualization of viruses. By demonstrating that a functional virus could be assembled from synthetic chemical components, it reinforced the nature of viruses as complex molecular machines that can be understood and manipulated through chemical synthesis (19). This has profound implications for virology, as it means viral "life" can be understood and manipulated at a fundamental molecular level, opening avenues for rational design of antiviral strategies and vaccines based purely on sequence information, rather than solely relying on natural isolates. This underscores the immense power of artificial recombination—assembling synthetic DNA fragments—to create functional biological entities from scratch, blurring the lines between chemistry and biology.
 
 While synthetic genomics offers immense promise for vaccine development, understanding viral pathogenesis, and creating novel therapeutic agents, it simultaneously presents a significant biosecurity and ethical challenge. The capability to recreate known pathogens or design novel ones from publicly available sequence data necessitates robust international regulatory frameworks, ongoing ethical discussions, and proactive measures to prevent misuse (22). The "uproar" and "widespread responses" to Wimmer's work, including ethical concerns and national security issues, directly highlight the societal implications of such powerful artificial recombination capabilities (22). This underscores a critical societal implication of biotechnological innovation: the imperative for a careful balance between scientific advancement and responsible governance to mitigate potential risks inherent in technologies that enable such powerful artificial recombination.
+
+[Back to Top](#top)
 
 ## 3. Cutting-Edge Technologies for Probing Viral Evolution and Function
 
@@ -66,9 +71,13 @@ DMS moves beyond simply observing past evolutionary events to predicting future 
 
 Viral evolution is not solely driven by the additive effects of individual mutations; epistatic interactions, where the effect of one mutation is dependent on the presence of other mutations, are crucial for shaping fitness landscapes and evolutionary pathways (38). DMS, by generating comprehensive mutant libraries and high-resolution fitness data, provides the raw material to computationally infer these complex, non-additive interactions (38). For instance, DMS has advanced the understanding of epistatic mechanisms in viral proteins and can be used to predict protein structures (38). Understanding epistasis is vital for predicting how multiple mutations, potentially arising from natural recombination events or introduced via artificial recombination, might combine to alter viral fitness or pathogenicity in unexpected ways. This deepens our understanding of the constraints and accessible pathways of viral adaptation, moving beyond simple additive models of fitness to a more nuanced, multi-locus perspective.
 
+[Back to Top](#top)
+
 ## Conclusion
 
 The biotechnologies described above represent a spectrum of tools that have revolutionized virology. From foundational techniques enabling gene cloning and expression to advanced methods allowing for precise genome editing and high-throughput functional analysis, these innovations continuously expand our capacity to study, understand, and combat viruses. Their ongoing development and application are key to addressing emerging viral threats and harnessing viruses for therapeutic purposes.
+
+[Back to Top](#top)
 
 ## Reference List
 

--- a/docs/virus_biology_and_analysis/condensed_virus_evolution_report.md
+++ b/docs/virus_biology_and_analysis/condensed_virus_evolution_report.md
@@ -1,8 +1,11 @@
+<a name="top"></a>
 # Major Stepwise Advancements in Virus Evolution and Biotechnological Innovation: The Central Role of Recombination - Condensed Report
 
 ## Abstract
 
 This report provides a concise overview of seminal advancements in the study of virus evolution and associated biotechnological innovations. Key technologies, including cDNA libraries, plasmid technology, CRISPR-Cas systems, synthetic genome construction (e.g., Wimmer's poliovirus), and historical virus reconstruction (e.g., Taubenberger's 1918 influenza work), have profoundly shaped our understanding of viral dynamics. A central theme is the pivotal role of both natural and artificial recombination in driving viral diversity, adaptation, and emergence, as well as enabling cutting-edge research methodologies like experimental evolution (EE) and deep mutational scanning (DMS).
+
+[Back to Top](#top)
 
 ## 1. Introduction: The Dynamic Nature of Viral Evolution
 
@@ -15,6 +18,8 @@ Viral evolution is a continuous and multifaceted process driven by fundamental m
     -   **Reassortment:** A distinct mechanism for segmented RNA viruses (e.g., orthomyxoviruses like influenza), involving the shuffling of complete genome segments upon co-infection (2).
 -   **Significance:** Recombination and reassortment enable immediate, large-scale genetic alterations, allowing viruses to adapt more rapidly than through gradual point mutations. This has profound implications for public health, as viruses can potentially outpace vaccine development or antiviral interventions.
 -   **Holistic Understanding:** Predicting and understanding viral emergence requires an integrated approach that combines molecular biology (how recombination occurs) with ecological and epidemiological factors (where and when co-infection happens, host susceptibility, cellular environment, and post-recombination fitness) (7, 4).
+
+[Back to Top](#top)
 
 ## 2. Foundational Biotechnologies for Viral Study
 
@@ -41,6 +46,8 @@ Viral evolution is a continuous and multifaceted process driven by fundamental m
     -   Production of recombinant viral vectors (e.g., Adeno-associated virus (AAV), lentivirus, adenovirus) for gene therapy, vaccination, and oncology research (15, 16).
 -   **Core Impact:** Plasmids are fundamental for controlled genetic exchange, allowing precise combination of disparate genetic elements (viral genes, promoters, markers) into a single, functional, replicable unit. This underpins modern viral engineering and has transformed virology into a field capable of active manipulation and design (15).
 
+[Back to Top](#top)
+
 ## 3. Seminal Breakthroughs in Viral Reconstruction and Synthetic Biology
 
 ### 3.1. Synthetic Genomes: Eckard Wimmer's Poliovirus and the Era of De Novo Virus Synthesis
@@ -62,6 +69,8 @@ Viral evolution is a continuous and multifaceted process driven by fundamental m
     -   Revealed the 1918 virus as a "founder virus"; subsequent influenza A pandemics (1957 H2N2, 1968 H3N2, 2009 H1N1) were caused by its descendants that acquired genes via reassortment (4).
     -   Empirically demonstrated reassortment as a key mechanism for rapid novel virus creation and major antigenic shifts (4, 26).
 -   **Impact:** Transformed historical epidemiology into an experimental science. Insights are directly applicable to current pandemic preparedness, informing vaccine strategies by elucidating the genetic basis of virulence. This is a powerful example of how artificial recombination (reconstituting a virus from cloned segments) provides understanding of natural recombination (reassortment).
+
+[Back to Top](#top)
 
 ## 4. Cutting-Edge Technologies for Probing Viral Evolution and Function
 
@@ -102,6 +111,8 @@ Viral evolution is a continuous and multifaceted process driven by fundamental m
     -   Analyzing mutation impacts (e.g., SARS-CoV-2 receptor binding domain on ACE2 binding and immune escape) to guide vaccine design (39, 41).
 -   **Impact:** Moves beyond observing past evolution to predicting future trajectories and escape pathways (38). Data on SARS-CoV-2 spike protein captured mutations that later became prevalent (40). Crucial for understanding epistasis (non-additive effects of multiple mutations), which is vital for predicting how mutations from recombination might alter viral fitness.
 
+[Back to Top](#top)
+
 ## 5. Synthesis: Recombination as a Driving Force in Viral Evolution and Biotechnological Innovation
 
 -   **Natural Recombination's Role:** A paramount evolutionary force (1). Reassortment in segmented viruses (e.g., influenza A) causes rapid, drastic genomic/phenotypic shifts, driving pandemic emergence (e.g., 1918 flu descendants) and viral emergence (e.g., Ngari virus) (4, 26, 5). It facilitates immune evasion and host adaptation (5). "Copy choice" recombination in non-segmented RNA viruses (e.g., coronaviruses) creates chimeric RNAs, aiding cross-species transmission (e.g., SARS-CoV-1, MERS-CoV) (2, 7). Recombination also repairs deleterious mutations and increases fitness variance, enhancing natural selection (7, 44).
@@ -115,6 +126,8 @@ Viral evolution is a continuous and multifaceted process driven by fundamental m
 
 -   **Theory and Empiricism:** Biotechnologies empirically validate, quantify, and refine theoretical understanding of viral evolution (mutation, recombination, selection) (1). EE demonstrates adaptive outcomes of genetic exchange (34, 35). DMS provides quantitative fitness data for constructing detailed landscapes (38). 1918 flu reconstruction validated reassortment's impact (26).
 
+[Back to Top](#top)
+
 ## 6. Conclusion
 
 The study of virus evolution has been profoundly advanced by biotechnological innovations, with recombination (natural and artificial) as a central theme.
@@ -123,6 +136,8 @@ The study of virus evolution has been profoundly advanced by biotechnological in
 -   **High-Throughput Methods:** Experimental evolution (EE) and deep mutational scanning (DMS) provide unprecedented empirical data on evolutionary dynamics and fitness landscapes, crucial for anticipating viral adaptation and understanding epistasis.
 
 The synergistic relationship between understanding natural viral recombination and leveraging artificial recombination through biotechnology creates a powerful feedback loop: discoveries inspire new technologies, which generate data that refines models and informs public health. The ongoing challenge is balancing the immense potential of these technologies with the critical need for responsible governance and biosecurity.
+
+[Back to Top](#top)
 
 ## Reference List
 


### PR DESCRIPTION
This commit introduces a 'Back to Top' feature in two key virology documents:
- docs/virus_biology_and_analysis/biotechnologies_in_virology_guide.md
- docs/virus_biology_and_analysis/condensed_virus_evolution_report.md

An HTML anchor (<a name="top"></a>) was added at the beginning of each file. 'Back to Top' Markdown links ([Back to Top](#top)) were inserted at the end of major sections in each document to improve navigation within these lengthy files.