### PR TITLE
Docs: Add SARS-CoV-2 Lineage Classification Pipeline to ToCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The scripts and library components provided here are for research and informatio
     *   [G. Special Topic: Virus Genomics, Diversity, and Analysis](#g-special-topic-virus-genomics-diversity-and-analysis)
     *   [H. VCF File Analysis and Filtering](#h-vcf-file-analysis-and-filtering)
     *   [I. Extracting and Analyzing CDS Regions](#i-extracting-and-analyzing-cds-regions)
+    *   [J. SARS-CoV-2 Lineage Classification Pipeline](#j-sars-cov-2-lineage-classification-pipeline)
 8.  [Detailed Script Usage](#detailed-script-usage)
 9.  [Development and Contributions](#development-and-contributions)
 10. [Citation](#citation)
@@ -564,6 +565,12 @@ For detailed usage instructions, command-line options, input/output formats, and
     python pylib/scripts/extract_cds_region.py my_genome.gb --single_position 1234
     ```
     This command would provide details about the codon and amino acid related to nucleotide position 1234 in `my_genome.gb`.
+
+[Back to Top](#top)
+
+### J. SARS-CoV-2 Lineage Classification Pipeline
+
+[Documentation for the SARS-CoV-2 Lineage Classification Pipeline](docs/virus_biology_and_analysis/pipelines/sars_cov2_lineage_classification/README.md)
 
 [Back to Top](#top)
 

--- a/docs/virus_biology_and_analysis/README.md
+++ b/docs/virus_biology_and_analysis/README.md
@@ -8,6 +8,7 @@ This section of the EvolCat-Python documentation focuses on topics related to vi
 *   [**Guide to Key Biotechnologies in Virology Research**](./biotechnologies_in_virology_guide.md): An overview of foundational and cutting-edge biotechnologies used in virology.
 *   [**Guide to Estimating Mutational Fitness Effects from Large-Scale Viral Sequence Data**](./estimating_mutation_fitness_effects_guide.md): Outlines a methodology for estimating mutation fitness effects based on observed vs. expected mutation counts from sequence data.
 *   [**UShER Toolkit and matUtils: A Condensed Guide**](./usher_toolkit_report.md): A guide to using the UShER toolkit and `matUtils` for phylogenetic placement and analysis of large viral datasets, particularly SARS-CoV-2.
+*   [**SARS-CoV-2 Lineage Classification Pipeline**](./pipelines/sars_cov2_lineage_classification/README.md): Documentation for the SARS-CoV-2 lineage classification pipeline.
 
 =======
 


### PR DESCRIPTION
Adds a link to the SARS-CoV-2 Lineage Classification Pipeline documentation in the Table of Contents of the main README.md and the docs/virus_biology_and_analysis/README.md file.