### PR TITLE
Fix: Correct path resolution in vcf_analysis_tools test_runner.sh

### DIFF
--- a/pylib/scripts/vcf_analysis_tools/test_runner.sh
+++ b/pylib/scripts/vcf_analysis_tools/test_runner.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 
-# Define paths
-SCRIPT_PATH="../pylib/scripts/analyze_vcf.py"
-INPUT_VCF="test_data/input.vcf"
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Define paths relative to SCRIPT_DIR
+SCRIPT_PATH="$SCRIPT_DIR/../analyze_vcf.py"
+INPUT_VCF="$SCRIPT_DIR/test_data/input.vcf"
 
 # Test Case 1: Filtered VCF
-OUTPUT_FILTERED_VCF_ACTUAL="test_data/actual_filtered_q45_d20.vcf"
-EXPECTED_FILTERED_VCF="test_data/expected_filtered_q45_d20.vcf"
+OUTPUT_FILTERED_VCF_ACTUAL="$SCRIPT_DIR/test_data/actual_filtered_q45_d20.vcf"
+EXPECTED_FILTERED_VCF="$SCRIPT_DIR/test_data/expected_filtered_q45_d20.vcf"
 MIN_QUAL_1=45
 MIN_DP_1=20
 
 # Test Case 2: Summary Report
-OUTPUT_SUMMARY_REPORT_ACTUAL="test_data/actual_report_q30_d35.tsv"
-EXPECTED_SUMMARY_REPORT="test_data/expected_report_q30_d35.tsv"
+OUTPUT_SUMMARY_REPORT_ACTUAL="$SCRIPT_DIR/test_data/actual_report_q30_d35.tsv"
+EXPECTED_SUMMARY_REPORT="$SCRIPT_DIR/test_data/expected_report_q30_d35.tsv"
 MIN_QUAL_2=30
 MIN_DP_2=35
 


### PR DESCRIPTION
The test_runner.sh script was failing because the relative path to the analyze_vcf.py script was incorrect after the script was moved to a new directory.

This commit updates the SCRIPT_PATH in test_runner.sh to correctly point to analyze_vcf.py.

Additionally, the script has been made more robust by ensuring all internal file paths are resolved relative to the script's own directory. This allows the script to be run from any location.

All tests in test_runner.sh now pass.