### PR TITLE
Clean up references in markdown guides

### DIFF
--- a/guides/biotechnologies_in_virology_guide.md
+++ b/guides/biotechnologies_in_virology_guide.md
@@ -21,37 +21,37 @@ This guide provides an overview of foundational and cutting-edge biotechnologies
 
 ### 1.1. cDNA Libraries
 <a name="11-cdna-libraries"></a>
-A cDNA library is a collection of complementary DNA (cDNA) fragments synthesized from messenger RNA (mRNA) using the enzyme reverse transcriptase [8]. Unlike genomic DNA libraries, cDNA libraries represent only the genes being actively expressed (transcribed) in a specific cell or tissue at a specific time, as they exclude non-coding regions like introns [8, 9].
+A cDNA library is a collection of complementary DNA (cDNA) fragments synthesized from messenger RNA (mRNA) using the enzyme reverse transcriptase [1]. Unlike genomic DNA libraries, cDNA libraries represent only the genes being actively expressed (transcribed) in a specific cell or tissue at a specific time, as they exclude non-coding regions like introns [1, 2].
 
 The construction process involves several key steps:
-1.  **mRNA Isolation:** mRNA is purified from other cellular RNA, often by targeting the poly-A tail unique to eukaryotic mRNA [11].
-2.  **First Strand Synthesis:** Reverse transcriptase synthesizes a single strand of cDNA using the mRNA as a template [11].
-3.  **Second Strand Synthesis:** The mRNA strand is removed, and DNA polymerase synthesizes the complementary DNA strand, creating double-stranded cDNA (ds-cDNA) [11].
-4.  **Cloning:** The ds-cDNA is ligated into a vector (like a plasmid) and amplified in host cells to create the library [10].
+1.  **mRNA Isolation:** mRNA is purified from other cellular RNA, often by targeting the poly-A tail unique to eukaryotic mRNA [4].
+2.  **First Strand Synthesis:** Reverse transcriptase synthesizes a single strand of cDNA using the mRNA as a template [4].
+3.  **Second Strand Synthesis:** The mRNA strand is removed, and DNA polymerase synthesizes the complementary DNA strand, creating double-stranded cDNA (ds-cDNA) [4].
+4.  **Cloning:** The ds-cDNA is ligated into a vector (like a plasmid) and amplified in host cells to create the library [3].
 
-> **Core Purpose:** The transformation of transient, single-stranded mRNA molecules into stable, double-stranded DNA copies is a critical biotechnological advancement. mRNA cannot be directly cloned; it must first be converted into DNA [12]. This is especially crucial for studying RNA viruses, allowing their unstable genomes to be cloned, sequenced, and engineered using robust DNA-based techniques.
+> **Core Purpose:** The transformation of transient, single-stranded mRNA molecules into stable, double-stranded DNA copies is a critical biotechnological advancement. mRNA cannot be directly cloned; it must first be converted into DNA [5]. This is especially crucial for studying RNA viruses, allowing their unstable genomes to be cloned, sequenced, and engineered using robust DNA-based techniques.
 
 In virology, cDNA libraries are used for:
-*   **Full-Length Gene Cloning:** Obtaining complete coding sequences of viral genes without introns [8].
-*   **Gene Expression Studies:** Producing recombinant viral proteins for structural/functional analysis or vaccine development [8].
-*   **Tracking Viral Evolution:** Detecting gene mutations to identify emerging variants [8].
+*   **Full-Length Gene Cloning:** Obtaining complete coding sequences of viral genes without introns [1].
+*   **Gene Expression Studies:** Producing recombinant viral proteins for structural/functional analysis or vaccine development [1].
+*   **Tracking Viral Evolution:** Detecting gene mutations to identify emerging variants [1].
 
 <details>
 <summary><b>A Deeper Dive: Normalized cDNA Libraries</b></summary>
 
-Conventional cDNA libraries often over-represent highly expressed genes, making it difficult to discover rare but functionally critical transcripts. **Normalized cDNA libraries** address this by adjusting the frequencies of clones to be more comparable. In virology, this allows for the discovery of a broader spectrum of viral and host transcripts, providing a more complete and unbiased picture of virus-host interactions and potential therapeutic targets [14].
+Conventional cDNA libraries often over-represent highly expressed genes, making it difficult to discover rare but functionally critical transcripts. **Normalized cDNA libraries** address this by adjusting the frequencies of clones to be more comparable. In virology, this allows for the discovery of a broader spectrum of viral and host transcripts, providing a more complete and unbiased picture of virus-host interactions and potential therapeutic targets [6].
 </details>
 
 [Back to Top](#top)
 
 ### 1.2. Plasmid Technology
 <a name="12-plasmid-technology"></a>
-Plasmids are small, circular, extrachromosomal DNA molecules that can replicate independently within a host cell, typically bacteria [15]. They are the workhorses of recombinant DNA technology. A typical engineered plasmid contains:
+Plasmids are small, circular, extrachromosomal DNA molecules that can replicate independently within a host cell, typically bacteria [7]. They are the workhorses of recombinant DNA technology. A typical engineered plasmid contains:
 *   An **origin of replication (ori)** for amplification in bacteria.
 *   An **antibiotic-resistance gene** for selecting cells that have successfully taken up the plasmid.
-*   A **multiple cloning site (MCS)** with unique restriction enzyme sites for inserting foreign DNA [15].
+*   A **multiple cloning site (MCS)** with unique restriction enzyme sites for inserting foreign DNA [7].
 
-Plasmids are indispensable for molecular cloning of viral genetic material. They allow scientists to insert a gene of interest into the plasmid, amplify it in bacteria, and then use it for a variety of applications, such as expressing viral proteins, producing antigens for vaccines, or building viral vectors for gene therapy [15, 16].
+Plasmids are indispensable for molecular cloning of viral genetic material. They allow scientists to insert a gene of interest into the plasmid, amplify it in bacteria, and then use it for a variety of applications, such as expressing viral proteins, producing antigens for vaccines, or building viral vectors for gene therapy [7, 8].
 
 > **Core Purpose:** Plasmids serve as the fundamental enabling platform for controlled genetic exchange in the laboratory. Their power lies in the ability to precisely combine disparate genetic elements—a viral gene, a specific promoter, a resistance marker, a fluorescent tag—into a single, functional, and replicable unit. This underpins virtually all modern viral engineering.
 
@@ -63,12 +63,12 @@ Plasmids are indispensable for molecular cloning of viral genetic material. They
 
 ### 2.1. Synthetic Genomes (Eckard Wimmer's Poliovirus)
 <a name="21-synthetic-genomes"></a>
-In a landmark 2002 achievement, Eckard Wimmer's team synthesized the poliovirus genome *de novo* from its publicly available sequence, without using a natural template [11, 20]. They assembled a full-length cDNA of the viral genome from short, custom-made oligonucleotides. This synthetic DNA was then transcribed into infectious viral RNA, which was "booted to life" in a cell-free extract to produce authentic, infectious poliovirus [20].
+In a landmark 2002 achievement, Eckard Wimmer's team synthesized the poliovirus genome *de novo* from its publicly available sequence, without using a natural template [4, 10]. They assembled a full-length cDNA of the viral genome from short, custom-made oligonucleotides. This synthetic DNA was then transcribed into infectious viral RNA, which was "booted to life" in a cell-free extract to produce authentic, infectious poliovirus [10].
 
 This work provided the ultimate proof that the poliovirus sequence was correct and fundamentally altered the scientific paradigm.
-> **Key Insight:** Wimmer's breakthrough shifted the perspective of viruses from purely biological entities to "chemicals with a life cycle" [22]. It proved that a replicating "organism" could be resurrected from pure genomic information, ushering in the era of synthetic biology where organisms could have "computers as parents" [23].
+> **Key Insight:** Wimmer's breakthrough shifted the perspective of viruses from purely biological entities to "chemicals with a life cycle" [12]. It proved that a replicating "organism" could be resurrected from pure genomic information, ushering in the era of synthetic biology where organisms could have "computers as parents" [13].
 
-This capability has vast implications, enabling rapid vaccine development and powerful new ways to study viral gene function [19, 21]. However, it also raised significant biosecurity concerns, highlighting the dual-use nature of advanced biotechnology and the need for responsible governance [22].
+This capability has vast implications, enabling rapid vaccine development and powerful new ways to study viral gene function [9, 11]. However, it also raised significant biosecurity concerns, highlighting the dual-use nature of advanced biotechnology and the need for responsible governance [12].
 
 [Back to Top](#top)
 
@@ -78,43 +78,43 @@ This capability has vast implications, enabling rapid vaccine development and po
 
 ### 3.1. CRISPR-Cas Systems
 <a name="31-crispr-cas-systems"></a>
-Clustered Regularly Interspaced Short Palindromic Repeats (CRISPR) and CRISPR-associated (Cas) proteins form a natural adaptive immune system in bacteria against invading viruses [27]. The most adapted version for genome editing, **CRISPR-Cas9**, uses two components:
+Clustered Regularly Interspaced Short Palindromic Repeats (CRISPR) and CRISPR-associated (Cas) proteins form a natural adaptive immune system in bacteria against invading viruses [14]. The most adapted version for genome editing, **CRISPR-Cas9**, uses two components:
 1.  **Cas9 Enzyme:** A protein that acts as "molecular scissors" to cut DNA.
-2.  **Guide RNA (gRNA):** A synthetic RNA molecule that guides Cas9 to a precise location in the genome to make a cut [30].
+2.  **Guide RNA (gRNA):** A synthetic RNA molecule that guides Cas9 to a precise location in the genome to make a cut [16].
 
-The cell's natural DNA repair mechanisms can then be leveraged to knock out genes or insert new genetic material at the site of the cut [27].
+The cell's natural DNA repair mechanisms can then be leveraged to knock out genes or insert new genetic material at the site of the cut [14].
 
-> **Core Advantage:** While older technologies like plasmids enabled broad genetic manipulation, CRISPR-Cas provides unprecedented **precision**. This allows researchers to engineer viral genomes with single-nucleotide accuracy, dissecting gene function, creating attenuated vaccine strains, and directly testing hypotheses about specific mutations with unparalleled control [29].
+> **Core Advantage:** While older technologies like plasmids enabled broad genetic manipulation, CRISPR-Cas provides unprecedented **precision**. This allows researchers to engineer viral genomes with single-nucleotide accuracy, dissecting gene function, creating attenuated vaccine strains, and directly testing hypotheses about specific mutations with unparalleled control [15].
 
-CRISPR has revolutionized virology by enabling the direct targeting of viral DNA/RNA, editing of host genes to confer viral resistance, and accelerating the development of novel antiviral therapies and diagnostics [29, 31].
+CRISPR has revolutionized virology by enabling the direct targeting of viral DNA/RNA, editing of host genes to confer viral resistance, and accelerating the development of novel antiviral therapies and diagnostics [15, 17].
 
 [Back to Top](#top)
 
 ### 3.2. Experimental Evolution (EE)
 <a name="32-experimental-evolution-ee"></a>
-Experimental Evolution (EE) involves propagating microbial populations, like viruses, in controlled lab environments for many generations to observe evolution in real-time [34]. Viruses are ideal for EE due to their short generation times and large population sizes. A key advantage is the ability to freeze "ancestral" populations and later revive them for direct comparison against their evolved descendants [34].
+Experimental Evolution (EE) involves propagating microbial populations, like viruses, in controlled lab environments for many generations to observe evolution in real-time [18]. Viruses are ideal for EE due to their short generation times and large population sizes. A key advantage is the ability to freeze "ancestral" populations and later revive them for direct comparison against their evolved descendants [18].
 
 > **Core Advantage:** EE offers the unique ability to observe **"evolution-in-action."** It moves beyond inferring historical events from static sequence data (phylogenetics) to actively demonstrating the dynamics and fitness consequences of genetic exchange and mutation. It allows for the controlled "replay" of evolutionary scenarios.
 
 In virology, EE is crucial for:
-*   Quantifying the fitness effects of mutations under specific selective pressures (e.g., antiviral drugs, new hosts) [34].
-*   Directly observing the mechanisms and consequences of recombination and reassortment [34].
+*   Quantifying the fitness effects of mutations under specific selective pressures (e.g., antiviral drugs, new hosts) [18].
+*   Directly observing the mechanisms and consequences of recombination and reassortment [18].
 *   Providing an empirical link between genetic changes and observable phenotypes, which is vital for predicting viral behavior.
 
 [Back to Top](#top)
 
 ### 3.3. Deep Mutational Scanning (DMS)
 <a name="33-deep-mutational-scanning-dms"></a>
-Deep Mutational Scanning (DMS) is a high-throughput technique that systematically maps how thousands of different mutations affect a viral protein's function [38]. The process involves:
+Deep Mutational Scanning (DMS) is a high-throughput technique that systematically maps how thousands of different mutations affect a viral protein's function [19]. The process involves:
 1.  **Generating a Library:** Creating a comprehensive library of viral genes, each with a specific mutation.
 2.  **Selection Assay:** Subjecting this library to a functional challenge (e.g., viral replication, antibody binding).
 3.  **Deep Sequencing:** Using Next-Generation Sequencing (NGS) to count the frequency of each mutant before and after selection to determine its "fitness."
 
-The result is a detailed "fitness map" that shows which parts of a protein are essential and which can tolerate change [38].
+The result is a detailed "fitness map" that shows which parts of a protein are essential and which can tolerate change [19].
 
-> **Core Advantage:** DMS moves beyond observing past evolution to **predicting future evolutionary trajectories**. By mapping the entire mutational landscape, researchers can identify potential drug resistance or immune escape mutations *before* they become prevalent in nature. This transforms public health from a reactive to a predictive and preventative strategy [38, 40].
+> **Core Advantage:** DMS moves beyond observing past evolution to **predicting future evolutionary trajectories**. By mapping the entire mutational landscape, researchers can identify potential drug resistance or immune escape mutations *before* they become prevalent in nature. This transforms public health from a reactive to a predictive and preventative strategy [19, 21].
 
-DMS has been instrumental in analyzing the SARS-CoV-2 spike protein to understand ACE2 binding and immune escape, directly guiding vaccine design [39, 41]. It is also a powerful tool for understanding epistasis—how the effect of one mutation depends on the presence of others [38].
+DMS has been instrumental in analyzing the SARS-CoV-2 spike protein to understand ACE2 binding and immune escape, directly guiding vaccine design [20, 22]. It is also a powerful tool for understanding epistasis—how the effect of one mutation depends on the presence of others [19].
 
 [Back to Top](#top)
 
@@ -128,50 +128,28 @@ The biotechnologies described here represent a spectrum of tools that have trans
 
 *(Note: The reference list has been formatted for clarity. The numbers correspond to the citations in the original text.)*
 
-1.  [vetres.org (Mutation, recombination...)](https://www.vetres.org/articles/vetres/full_html/2010/06/v09583/v09583.html)
-2.  [Virus Evolution and Genetics - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC7173474/)
-3.  [Viral Genetic Recombination - Flashcards World](https://flashcards.world/flashcards/sets/1f20d75a-552e-4072-bbfe-ced52ac097c4/)
-4.  [Viral reassortment as an information exchange - PNAS](https://www.pnas.org/doi/10.1073/pnas.1113300109)
-5.  [Number and Pattern of Viral Genomic Reassortments - MBE | Oxford Academic](https://academic.oup.com/mbe/article/41/6/msae078/7656017)
-6.  [Mechanisms of homologous recombination - ResearchGate](https://www.researchgate.net/figure/Mechanisms-of-homologous-recombination-and-non-homologous-recombination-A-Homologous_fig1_380279457)
-7.  [The coronavirus recombination pathway - UC Davis](https://anthonylab.vetmed.ucdavis.edu/sites/g/files/dgvnsk11301/files/inline-files/The-coronavirus-recombination-pathway_chom.pdf)
-8.  [cDNA: Current Applications and Future Horizons | CD Genomics](https://www.cd-genomics.com/blog/cdna-application-gene-cloning-pcr-drug-development/)
-9.  [cDNA Library Overview and Applications - Creative Biogene](https://www.creative-biogene.com/support/cdna-library-overview-and-applications.html)
-10. [DNA Library (Genomic, cDNA) - Microbe Notes](https://microbenotes.com/dna-library-gene-library/)
-11. [Five Steps to Optimal cDNA Synthesis | Thermo Fisher Scientific](https://www.thermofisher.com/us/en/home/life-science/pcr/reverse-transcription/5steps-cDNA.html)
-12. [Principle and procedure for making Genomic library and cDNA - Slideshare](https://www.slideshare.net/slideshow/principle-and-procedure-for-making-genomic-library-and-cdna-librarypptx/258210824)
-13. [cDNA Library Construction Protocol - Creative Biogene](https://www.creative-biogene.com/support/cdna-library-construction-protocol.html)
-14. [Construction of normalized cDNA libraries - Columbia Technology Ventures](https://inventions.techventures.columbia.edu/technologies/construction-of--352)
-15. [Molecular Biology Reference - Addgene](https://www.addgene.org/mol-bio-reference/)
-16. [Cell and Gene Therapy Research | Plasmid DNA and Viral Vectors - BioInnovatise](https://bioinnovatise.com/research-areas/cell-and-gene-therapy/)
-17. [Plasmids | University of Michigan Medical School](https://medresearch.umich.edu/office-research/about-office-research/biomedical-research-core-facilities/vector-core/plasmids)
-18. [bioinnovatise.com (Viral Vector Production)](https://bioinnovatise.com/research-areas/cell-and-gene-therapy/#:~:text=Viral%20Vector%20Production%3A%20Plasmids%20are,vectors%20containing%20the%20therapeutic%20gene.)
-19. [Profile of Eckard Wimmer - PNAS](https://www.pnas.org/doi/10.1073/pnas.1221558110)
-20. [Poliovirus Case Study - Federation of American Scientists](https://biosecurity.fas.org/education/dualuse/FAS_Wimmer/FAS_Topic_2_A.html)
-21. [Synthetic Poliovirus and Other Designer Viruses - Annual Reviews](https://www.annualreviews.org/content/journals/10.1146/annurev-micro-090110-102957)
-22. [The test‐tube synthesis of poliovirus - EMBO Press](https://www.embopress.org/doi/10.1038/sj.embor.7400728)
-23. [Eckard Wimmer - Wikipedia](https://en.wikipedia.org/wiki/Eckard_Wimmer)
-24. [Reconstruction of the 1918 Pandemic Virus - CDC Archive](https://archive.cdc.gov/www_cdc_gov/flu/pandemic-resources/reconstruction-1918-virus.html)
-25. [Scientific Investigation of the 1918 Flu - PBS](https://www.pbs.org/wgbh/americanexperience/features/influenza-investigation/)
-26. [The 1918 Influenza Pandemic and Its Legacy - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC7528857/)
-27. [CRISPR-Based Technologies - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC3981743/)
-28. [Scientists Discover New CRISPR Defense Mechanisms - Technology Networks](https://www.technologynetworks.com/genomics/news/scientists-discover-new-crispr-defense-mechanisms-to-halt-virus-spread-399836)
-29. [CRISPR Applications in Plant Virology - APS Journals](https://apsjournals.apsnet.org/doi/10.1094/PHYTO-07-19-0267-IA)
-30. [What is CRISPR-Cas9? - Your Genome](https://www.yourgenome.org/theme/what-is-crispr-cas9/)
-31. [Latest Advances of Virology Research Using CRISPR - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC8146441/)
-32. [CRISPR Guide - Addgene](https://www.addgene.org/guides/crispr/)
-33. [CRISPR-Cas Gene Editing Teaching Resources - Bio-Rad](https://www.bio-rad.com/en-us/applications-technologies/crispr-cas-gene-editing-teaching-resources?ID=Q58I0DWDLBV5)
-34. [Experimental Evolution Studies in Φ6 Cystovirus - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC11209170/)
-35. [Genome dynamics during experimental evolution - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC4239992/)
-36. [Experimental evolution of viruses: Microviridae - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC2935103/)
-37. [Experimental Evolution Studies in Φ6 Cystovirus - MDPI](https://www.mdpi.com/1999-4915/16/6/977)
-38. [Deep mutational scanning and CRISPR-engineered viruses - ASM Journals](https://journals.asm.org/doi/10.1128/msphere.00508-24)
-39. [DMS platform to characterize fitness landscape of anti-CRISPR proteins - NAR | Oxford](https://academic.oup.com/nar/article/52/22/e103/7903370)
-40. [DMS: A versatile tool in mapping genotypes to phenotypes - Frontiers](https://www.frontiersin.org/journals/genetics/articles/10.3389/fgene.2023.1087267/full)
-41. [DMS Comprehensively Maps Zika Envelope Protein Mutations - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC6854493/)
-42. [Applications of DMS in Virology - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC8227372/)
-43. [DMS of H5 hemagglutinin to inform influenza surveillance - PLOS](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3002916)
-44. [Experimental tests on the evolution of sex and recombination - J. of Evolutionary Biology | Oxford](https://academic.oup.com/jeb/advance-article/doi/10.1093/jeb/voaf028/8115572?searchresult=1)
+1.  [cDNA: Current Applications and Future Horizons | CD Genomics](https://www.cd-genomics.com/blog/cdna-application-gene-cloning-pcr-drug-development/)
+2.  [cDNA Library Overview and Applications - Creative Biogene](https://www.creative-biogene.com/support/cdna-library-overview-and-applications.html)
+3.  [DNA Library (Genomic, cDNA) - Microbe Notes](https://microbenotes.com/dna-library-gene-library/)
+4.  [Five Steps to Optimal cDNA Synthesis | Thermo Fisher Scientific](https://www.thermofisher.com/us/en/home/life-science/pcr/reverse-transcription/5steps-cDNA.html)
+5.  [Principle and procedure for making Genomic library and cDNA - Slideshare](https://www.slideshare.net/slideshow/principle-and-procedure-for-making-genomic-library-and-cdna-librarypptx/258210824)
+6.  [Construction of normalized cDNA libraries - Columbia Technology Ventures](https://inventions.techventures.columbia.edu/technologies/construction-of--352)
+7.  [Molecular Biology Reference - Addgene](https://www.addgene.org/mol-bio-reference/)
+8.  [Cell and Gene Therapy Research | Plasmid DNA and Viral Vectors - BioInnovatise](https://bioinnovatise.com/research-areas/cell-and-gene-therapy/)
+9.  [Profile of Eckard Wimmer - PNAS](https://www.pnas.org/doi/10.1073/pnas.1221558110)
+10. [Poliovirus Case Study - Federation of American Scientists](https://biosecurity.fas.org/education/dualuse/FAS_Wimmer/FAS_Topic_2_A.html)
+11. [Synthetic Poliovirus and Other Designer Viruses - Annual Reviews](https://www.annualreviews.org/content/journals/10.1146/annurev-micro-090110-102957)
+12. [The test‐tube synthesis of poliovirus - EMBO Press](https://www.embopress.org/doi/10.1038/sj.embor.7400728)
+13. [Eckard Wimmer - Wikipedia](https://en.wikipedia.org/wiki/Eckard_Wimmer)
+14. [CRISPR-Based Technologies - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC3981743/)
+15. [CRISPR Applications in Plant Virology - APS Journals](https://apsjournals.apsnet.org/doi/10.1094/PHYTO-07-19-0267-IA)
+16. [What is CRISPR-Cas9? - Your Genome](https://www.yourgenome.org/theme/what-is-crispr-cas9/)
+17. [Latest Advances of Virology Research Using CRISPR - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC8146441/)
+18. [Experimental Evolution Studies in Φ6 Cystovirus - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC11209170/)
+19. [Deep mutational scanning and CRISPR-engineered viruses - ASM Journals](https://journals.asm.org/doi/10.1128/msphere.00508-24)
+20. [DMS platform to characterize fitness landscape of anti-CRISPR proteins - NAR | Oxford](https://academic.oup.com/nar/article/52/22/e103/7903370)
+21. [DMS: A versatile tool in mapping genotypes to phenotypes - Frontiers](https://www.frontiersin.org/journals/genetics/articles/10.3389/fgene.2023.1087267/full)
+22. [DMS Comprehensively Maps Zika Envelope Protein Mutations - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC6854493/)
 
 </details>
 

--- a/guides/condensed_virus_evolution_report.md
+++ b/guides/condensed_virus_evolution_report.md
@@ -36,7 +36,7 @@ Viral evolution is a continuous process driven by **mutation, recombination, and
     *   **Recombination:** The exchange of genetic material between different viral genomes. In RNA viruses, a common mechanism is *"copy choice,"* where the replicase switches templates during replication (2).
     *   **Reassortment:** The shuffling of entire genome segments in segmented viruses (e.g., influenza) during co-infection (2).
 
-> **Impact:** These processes can cause drastic genomic and phenotypic changes, such as altered virulence or expanded host range. The 1918 influenza pandemic and its successors were driven by reassortment events (3, 4). Understanding viral emergence requires an integrated approach, combining molecular biology with ecology and epidemiology (7, 4).
+> **Impact:** These processes can cause drastic genomic and phenotypic changes, such as altered virulence or expanded host range. The 1918 influenza pandemic and its successors were driven by reassortment events (3, 4). Understanding viral emergence requires an integrated approach, combining molecular biology with ecology and epidemiology (5, 4).
 
 ---
 
@@ -44,12 +44,12 @@ Viral evolution is a continuous process driven by **mutation, recombination, and
 
 ### 2.1. cDNA Libraries: Revolutionizing Gene Expression Analysis
 
--   **Concept:** Collections of complementary DNA (cDNA) synthesized from an organism's messenger RNA (mRNA), representing the genes being actively expressed (8, 9).
--   **Core Impact:** The conversion of transient viral RNA into stable, clonable DNA is a critical biotechnological bridge. It enables the study of RNA viruses using powerful DNA-based molecular techniques and is foundational for reverse genetics systems (12).
+-   **Concept:** Collections of complementary DNA (cDNA) synthesized from an organism's messenger RNA (mRNA), representing the genes being actively expressed (6, 7).
+-   **Core Impact:** The conversion of transient viral RNA into stable, clonable DNA is a critical biotechnological bridge. It enables the study of RNA viruses using powerful DNA-based molecular techniques and is foundational for reverse genetics systems (8).
 
 ### 2.2. Plasmid Technology Enabling Genetic Manipulation
--   **Concept:** Small, circular, extrachromosomal DNA molecules used as vectors to carry and replicate foreign genes inside host cells (e.g., *E. coli*) (15).
--   **Core Impact:** Plasmids are the workhorses of molecular cloning. They allow the precise *artificial recombination* of disparate genetic elements (viral genes, promoters, markers) into a single, functional, replicable unit, underpinning modern viral engineering (15, 16).
+-   **Concept:** Small, circular, extrachromosomal DNA molecules used as vectors to carry and replicate foreign genes inside host cells (e.g., *E. coli*) (9).
+-   **Core Impact:** Plasmids are the workhorses of molecular cloning. They allow the precise *artificial recombination* of disparate genetic elements (viral genes, promoters, markers) into a single, functional, replicable unit, underpinning modern viral engineering (9, 10).
 
 ---
 
@@ -57,13 +57,13 @@ Viral evolution is a continuous process driven by **mutation, recombination, and
 
 ### 3.1. Synthetic Genomes: Eckard Wimmer's Poliovirus and the Era of De Novo Virus Synthesis
 
-> In 2002, Eckard Wimmer's team chemically synthesized the poliovirus genome *de novo* from its public sequence, without a natural template. This synthetic RNA, when incubated in a cell-free extract, produced authentic, infectious poliovirus (20).
+> In 2002, Eckard Wimmer's team chemically synthesized the poliovirus genome *de novo* from its public sequence, without a natural template. This synthetic RNA, when incubated in a cell-free extract, produced authentic, infectious poliovirus (12).
 
--   **Significance:** This work proved that a replicating biological entity could be created from pure digital information, shifting the paradigm of viruses to *"chemicals with a life cycle"* (22, 19). It ushered in the era of synthetic biology and provided powerful tools for studying gene function and creating vaccine candidates (21).
+-   **Significance:** This work proved that a replicating biological entity could be created from pure digital information, shifting the paradigm of viruses to *"chemicals with a life cycle"* (14, 11). It ushered in the era of synthetic biology and provided powerful tools for studying gene function and creating vaccine candidates (13).
 
 ### 3.2. Reconstructing the Past: Jeffery Taubenberger's Work on the 1918 Influenza Virus
 
-> Jeffery Taubenberger's team reconstructed the 1918 "Spanish" influenza virus by sequencing fragmented viral RNA from preserved lung tissues of victims. By 2005, they had resurrected the live virus using reverse genetics (24, 25).
+> Jeffery Taubenberger's team reconstructed the 1918 "Spanish" influenza virus by sequencing fragmented viral RNA from preserved lung tissues of victims. By 2005, they had resurrected the live virus using reverse genetics (15, 16).
 
 -   **Significance:** This transformed historical epidemiology into an experimental science. It revealed the 1918 virus as an avian-origin "founder" and empirically demonstrated that subsequent influenza pandemics were caused by its descendants acquiring new genes via **reassortment** (4). This work is a powerful example of using *artificial recombination* (reconstituting a virus from cloned parts) to understand *natural recombination* (reassortment).
 
@@ -73,18 +73,18 @@ Viral evolution is a continuous process driven by **mutation, recombination, and
 
 ### 4.1. CRISPR-Cas Systems: Precision Genome Engineering and Antiviral Strategies
 
--   **Concept:** Repurposed from a prokaryotic adaptive immune system, the CRISPR-Cas9 system uses a guide RNA (gRNA) to direct the Cas9 nuclease ("molecular scissors") to a specific DNA target, where it creates a precise cut (27, 30).
--   **Impact:** CRISPR provides unprecedented precision for *artificial recombination* at the single-nucleotide level. It allows researchers to create "designer" viruses to study gene function, map virulence factors, and develop attenuated vaccines (29, 31).
+-   **Concept:** Repurposed from a prokaryotic adaptive immune system, the CRISPR-Cas9 system uses a guide RNA (gRNA) to direct the Cas9 nuclease ("molecular scissors") to a specific DNA target, where it creates a precise cut (17, 19).
+-   **Impact:** CRISPR provides unprecedented precision for *artificial recombination* at the single-nucleotide level. It allows researchers to create "designer" viruses to study gene function, map virulence factors, and develop attenuated vaccines (18, 20).
 
 ### 4.2. Experimental Evolution (EE): Unraveling Adaptive Pathways in Real-Time
 
--   **Concept:** Propagating viral populations in controlled lab environments over many generations to observe evolutionary processes like adaptation in real-time (34).
--   **Impact:** EE allows direct observation of "evolution-in-action." For recombination, EE experiments can directly test how co-infection leads to reassortment and how the resulting genetic diversity contributes to adaptation, moving beyond inference from static sequence data (34, 35).
+-   **Concept:** Propagating viral populations in controlled lab environments over many generations to observe evolutionary processes like adaptation in real-time (21).
+-   **Impact:** EE allows direct observation of "evolution-in-action." For recombination, EE experiments can directly test how co-infection leads to reassortment and how the resulting genetic diversity contributes to adaptation, moving beyond inference from static sequence data (21, 22).
 
 ### 4.3. Deep Mutational Scanning (DMS): High-Resolution Mapping of Viral Fitness Landscapes
 
--   **Concept:** A high-throughput method that measures the functional consequence of thousands or millions of mutations simultaneously. A library of mutants is created, subjected to a selection pressure (e.g., viral replication), and deep sequencing is used to quantify the frequency change of each mutant (38).
--   **Impact:** DMS generates detailed "fitness maps" that reveal functional constraints and evolvability across a viral protein. This moves beyond observing past evolution to *predicting* future evolutionary trajectories and immune escape pathways, as demonstrated with the SARS-CoV-2 spike protein (39, 40).
+-   **Concept:** A high-throughput method that measures the functional consequence of thousands or millions of mutations simultaneously. A library of mutants is created, subjected to a selection pressure (e.g., viral replication), and deep sequencing is used to quantify the frequency change of each mutant (23).
+-   **Impact:** DMS generates detailed "fitness maps" that reveal functional constraints and evolvability across a viral protein. This moves beyond observing past evolution to *predicting* future evolutionary trajectories and immune escape pathways, as demonstrated with the SARS-CoV-2 spike protein (24, 25).
 
 ---
 
@@ -94,7 +94,7 @@ Recombination, both natural and artificial, is a central theme connecting viral 
 
 > **Natural Recombination** is the engine of rapid viral change. **Artificial Recombination** is the toolkit we use to understand and engineer that engine.
 
--   **Natural:** Reassortment drives influenza pandemics (4). Copy-choice recombination creates chimeric coronaviruses, aiding cross-species transmission (7).
+-   **Natural:** Reassortment drives influenza pandemics (4). Copy-choice recombination creates chimeric coronaviruses, aiding cross-species transmission (5).
 -   **Artificial:**
     -   *Foundational:* cDNA/plasmids enable cloning and reverse genetics.
     -   *Reconstruction:* Synthetic genomics (Wimmer) and historical resurrection (Taubenberger) represent ultimate forms of artificial recombination.
@@ -124,45 +124,26 @@ The synergistic relationship between understanding natural viral recombination a
 2.  [Virus Evolution and Genetics - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC7173474/)
 3.  [Viral Genetic Recombination - Flashcards World](https://flashcards.world/flashcards/sets/1f20d75a-552e-4072-bbfe-ced52ac097c4/)
 4.  [Viral reassortment as an information exchange - PNAS](https://www.pnas.org/doi/10.1073/pnas.1113300109)
-5.  [Number and Pattern of Viral Genomic Reassortments - MBE | Oxford Academic](https://academic.oup.com/mbe/article/41/6/msae078/7656017)
-6.  [Mechanisms of homologous recombination - ResearchGate](https://www.researchgate.net/figure/Mechanisms-of-homologous-recombination-and-non-homologous-recombination-A-Homologous_fig1_380279457)
-7.  [The coronavirus recombination pathway - UC Davis](https://anthonylab.vetmed.ucdavis.edu/sites/g/files/dgvnsk11301/files/inline-files/The-coronavirus-recombination-pathway_chom.pdf)
-8.  [cDNA: Current Applications and Future Horizons | CD Genomics](https://www.cd-genomics.com/blog/cdna-application-gene-cloning-pcr-drug-development/)
-9.  [cDNA Library Overview and Applications - Creative Biogene](https://www.creative-biogene.com/support/cdna-library-overview-and-applications.html)
-10. [DNA Library (Genomic, cDNA) - Microbe Notes](https://microbenotes.com/dna-library-gene-library/)
-11. [Five Steps to Optimal cDNA Synthesis | Thermo Fisher Scientific](https://www.thermofisher.com/us/en/home/life-science/pcr/reverse-transcription/5steps-cDNA.html)
-12. [Principle and procedure for making Genomic library and cDNA - Slideshare](https://www.slideshare.net/slideshow/principle-and-procedure-for-making-genomic-library-and-cdna-librarypptx/258210824)
-13. [cDNA Library Construction Protocol - Creative Biogene](https://www.creative-biogene.com/support/cdna-library-construction-protocol.html)
-14. [Construction of normalized cDNA libraries - Columbia Technology Ventures](https://inventions.techventures.columbia.edu/technologies/construction-of--352)
-15. [Molecular Biology Reference - Addgene](https://www.addgene.org/mol-bio-reference/)
-16. [Cell and Gene Therapy Research | Plasmid DNA and Viral Vectors - BioInnovatise](https://bioinnovatise.com/research-areas/cell-and-gene-therapy/)
-17. [Plasmids | University of Michigan Medical School](https://medresearch.umich.edu/office-research/about-office-research/biomedical-research-core-facilities/vector-core/plasmids)
-18. [bioinnovatise.com (Viral Vector Production)](https://bioinnovatise.com/research-areas/cell-and-gene-therapy/#:~:text=Viral%20Vector%20Production%3A%20Plasmids%20are,vectors%20containing%20the%20therapeutic%20gene.)
-19. [Profile of Eckard Wimmer - PNAS](https://www.pnas.org/doi/10.1073/pnas.1221558110)
-20. [Poliovirus Case Study - Federation of American Scientists](https://biosecurity.fas.org/education/dualuse/FAS_Wimmer/FAS_Topic_2_A.html)
-21. [Synthetic Poliovirus and Other Designer Viruses - Annual Reviews](https://www.annualreviews.org/content/journals/10.1146/annurev-micro-090110-102957)
-22. [The test‐tube synthesis of poliovirus - EMBO Press](https://www.embopress.org/doi/10.1038/sj.embor.7400728)
-23. [Eckard Wimmer - Wikipedia](https://en.wikipedia.org/wiki/Eckard_Wimmer)
-24. [Reconstruction of the 1918 Pandemic Virus - CDC Archive](https://archive.cdc.gov/www_cdc_gov/flu/pandemic-resources/reconstruction-1918-virus.html)
-25. [Scientific Investigation of the 1918 Flu - PBS](https://www.pbs.org/wgbh/americanexperience/features/influenza-investigation/)
-26. [The 1918 Influenza Pandemic and Its Legacy - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC7528857/)
-27. [CRISPR-Based Technologies - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC3981743/)
-28. [Scientists Discover New CRISPR Defense Mechanisms - Technology Networks](https://www.technologynetworks.com/genomics/news/scientists-discover-new-crispr-defense-mechanisms-to-halt-virus-spread-399836)
-29. [CRISPR Applications in Plant Virology - APS Journals](https://apsjournals.apsnet.org/doi/10.1094/PHYTO-07-19-0267-IA)
-30. [What is CRISPR-Cas9? - Your Genome](https://www.yourgenome.org/theme/what-is-crispr-cas9/)
-31. [Latest Advances of Virology Research Using CRISPR - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC8146441/)
-32. [CRISPR Guide - Addgene](https://www.addgene.org/guides/crispr/)
-33. [CRISPR-Cas Gene Editing Teaching Resources - Bio-Rad](https://www.bio-rad.com/en-us/applications-technologies/crispr-cas-gene-editing-teaching-resources?ID=Q58I0DWDLBV5)
-34. [Experimental Evolution Studies in Φ6 Cystovirus - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC11209170/)
-35. [Genome dynamics during experimental evolution - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC4239992/)
-36. [Experimental evolution of viruses: Microviridae - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC2935103/)
-37. [Experimental Evolution Studies in Φ6 Cystovirus - MDPI](https://www.mdpi.com/1999-4915/16/6/977)
-38. [Deep mutational scanning and CRISPR-engineered viruses - ASM Journals](https://journals.asm.org/doi/10.1128/msphere.00508-24)
-39. [DMS platform to characterize fitness landscape of anti-CRISPR proteins - NAR | Oxford](https://academic.oup.com/nar/article/52/22/e103/7903370)
-40. [DMS: A versatile tool in mapping genotypes to phenotypes - Frontiers](https://www.frontiersin.org/journals/genetics/articles/10.3389/fgene.2023.1087267/full)
-41. [DMS Comprehensively Maps Zika Envelope Protein Mutations - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC6854493/)
-42. [Applications of DMS in Virology - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC8227372/)
-43. [DMS of H5 hemagglutinin to inform influenza surveillance - PLOS](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3002916)
-44. [Experimental tests on the evolution of sex and recombination - J. of Evolutionary Biology | Oxford](https://academic.oup.com/jeb/advance-article/doi/10.1093/jeb/voaf028/8115572?searchresult=1)
+5.  [The coronavirus recombination pathway - UC Davis](https://anthonylab.vetmed.ucdavis.edu/sites/g/files/dgvnsk11301/files/inline-files/The-coronavirus-recombination-pathway_chom.pdf)
+6.  [cDNA: Current Applications and Future Horizons | CD Genomics](https://www.cd-genomics.com/blog/cdna-application-gene-cloning-pcr-drug-development/)
+7.  [cDNA Library Overview and Applications - Creative Biogene](https://www.creative-biogene.com/support/cdna-library-overview-and-applications.html)
+8.  [Principle and procedure for making Genomic library and cDNA - Slideshare](https://www.slideshare.net/slideshow/principle-and-procedure-for-making-genomic-library-and-cdna-librarypptx/258210824)
+9.  [Molecular Biology Reference - Addgene](https://www.addgene.org/mol-bio-reference/)
+10. [Cell and Gene Therapy Research | Plasmid DNA and Viral Vectors - BioInnovatise](https://bioinnovatise.com/research-areas/cell-and-gene-therapy/)
+11. [Profile of Eckard Wimmer - PNAS](https://www.pnas.org/doi/10.1073/pnas.1221558110)
+12. [Poliovirus Case Study - Federation of American Scientists](https://biosecurity.fas.org/education/dualuse/FAS_Wimmer/FAS_Topic_2_A.html)
+13. [Synthetic Poliovirus and Other Designer Viruses - Annual Reviews](https://www.annualreviews.org/content/journals/10.1146/annurev-micro-090110-102957)
+14. [The test‐tube synthesis of poliovirus - EMBO Press](https://www.embopress.org/doi/10.1038/sj.embor.7400728)
+15. [Reconstruction of the 1918 Pandemic Virus - CDC Archive](https://archive.cdc.gov/www_cdc_gov/flu/pandemic-resources/reconstruction-1918-virus.html)
+16. [Scientific Investigation of the 1918 Flu - PBS](https://www.pbs.org/wgbh/americanexperience/features/influenza-investigation/)
+17. [CRISPR-Based Technologies - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC3981743/)
+18. [CRISPR Applications in Plant Virology - APS Journals](https://apsjournals.apsnet.org/doi/10.1094/PHYTO-07-19-0267-IA)
+19. [What is CRISPR-Cas9? - Your Genome](https://www.yourgenome.org/theme/what-is-crispr-cas9/)
+20. [Latest Advances of Virology Research Using CRISPR - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC8146441/)
+21. [Experimental Evolution Studies in Φ6 Cystovirus - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC11209170/)
+22. [Genome dynamics during experimental evolution - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC4239992/)
+23. [Deep mutational scanning and CRISPR-engineered viruses - ASM Journals](https://journals.asm.org/doi/10.1128/msphere.00508-24)
+24. [DMS platform to characterize fitness landscape of anti-CRISPR proteins - NAR | Oxford](https://academic.oup.com/nar/article/52/22/e103/7903370)
+25. [DMS: A versatile tool in mapping genotypes to phenotypes - Frontiers](https://www.frontiersin.org/journals/genetics/articles/10.3389/fgene.2023.1087267/full)
 
 </details>


### PR DESCRIPTION
- Removed unused references from biotechnologies_in_virology_guide.md and condensed_virus_evolution_report.md.
- Renumbered remaining references and updated in-text citations accordingly in these two files.
- No changes were needed for usher_toolkit_report.md as it does not use numbered citations.