### PR TITLE
Expand Textbook with Toolkit Chapter

### DIFF
--- a/guides/VIRAL_EVOLUTION_TEXTBOOK.txt
+++ b/guides/VIRAL_EVOLUTION_TEXTBOOK.txt
@@ -12,6 +12,7 @@ Chapter 3: The Architecture of Viral Phylogenetics: Trees and Ancestral States
 Chapter 4: Deep Learning and Sequence-to-Sequence Modeling in Evolution
 Chapter 5: Ecological and Spatio-Temporal Dynamics of Viral Populations
 Chapter 6: Advanced Genomic Surveillance and Large-Scale Diversity Analysis
+Chapter 7: The EvolCat-Python Toolkit: Implementation and Practical Application
 Conclusion: Epistemology and the Future of Viral Surveillance
 Bibliography
 
@@ -466,6 +467,243 @@ Figure 9: F456L Frequency in the USA Only. Restricted analysis confirms that a s
 This case study underscores the necessity of geographic stratification. Failing to account for such biases can lead to incorrect inferences about viral fitness and misdirection of public health resources. By integrating scalable computational methods with population genetic theory, we can transform raw genomic data into actionable knowledge about the true dynamics of viral evolution.
 
 
+CHAPTER 7: THE EVOLCAT-PYTHON TOOLKIT: IMPLEMENTATION AND PRACTICAL APPLICATION
+
+Introduction to the Toolkit
+
+The EvolCat-Python project is more than a collection of disparate scripts; it is a cohesive ecosystem designed to bridge the gap between raw genomic data and sophisticated evolutionary inference. In the preceding chapters, we have explored the theoretical underpinnings of viral genomics, from the stochastic nature of mutation to the complex architecture of Transformer-based models. However, the realization of these theories depends entirely on the precision and reliability of the computational tools used to process the data. This chapter provides a thorough examination of the EvolCat-Python toolkit, detailing the implementation, biological relevance, and practical application of the scripts that power our research.
+
+The toolkit is organized into several functional modules, reflecting the natural progression of a bioinformatic workflow: data acquisition and conversion, genomic extraction, alignment and quality control, evolutionary metric calculation, phylogenetic reconstruction, and population-scale analysis. Each script is designed with a specific purpose in mind, often serving as a critical link in a larger automated pipeline. By grounding these tools in the principles of software engineering—such as modularity, documentation, and rigorous testing—we ensure that our evolutionary findings are built on a robust and reproducible foundation.
+
+A key philosophy of the EvolCat-Python toolkit is the empowerment of the researcher. Many of these tools are designed to be "standalone," meaning they minimize external dependencies and can be easily integrated into diverse environments. This is particularly important in the rapidly evolving field of virology, where new data formats and analytical requirements emerge frequently. Whether a researcher is analyzing a handful of sequences or processing millions of genomes from a global pandemic, the EvolCat-Python toolkit provides the necessary building blocks for rigorous scientific inquiry.
+
+Throughout this chapter, we will examine these tools through the lens of practical examples. We will see how a raw GenBank record can be transformed into a refined dataset for selection analysis, how a mutation-annotated tree can be used to reconstruct ancestral sequences for machine learning, and how global genomic surveillance can be scaled to detect selective sweeps in real-time. By mastering these tools, the researcher gains the capacity not only to observe viral evolution but to actively probe the mechanisms that drive it.
+
+
+Sequence Format Conversion and Data Interoperability
+
+Bioinformatics is characterized by a plurality of data formats, each optimized for different types of analysis. GenBank files (.gb, .gbk) are the standard for rich genomic annotations, providing detailed information about gene locations, protein products, and experimental metadata. FASTA files (.fasta, .fas, .fna) are the workhorse of sequence analysis, offering a simple and efficient way to store nucleotide or protein sequences. PHYLIP (.phy) and MEGA (.meg) formats are specialized for phylogenetic software, while CSV and TSV files are ideal for tabular data manipulation.
+
+The ability to move seamlessly between these formats is a prerequisite for any complex workflow. The EvolCat-Python toolkit includes a suite of conversion utilities designed to ensure data interoperability.
+
+`gb2fasta.py`: The Gateway to Sequence Analysis
+The conversion from GenBank to FASTA is often the first step in a bioinformatic pipeline. `gb2fasta.py` is a streamlined utility that extracts the primary nucleotide sequence (the ORIGIN block) from a GenBank record and formats it as a FASTA record. This is essential for tools that do not support the complexity of the GenBank format, such as alignment programs or simple sequence scanners.
+
+`fas2phy.py` and `phy2fas.py`: Bridging the Gap to Phylogenetics
+Phylogenetic analysis often requires the PHYLIP format, which is characterized by a header indicating the number of sequences and their length, followed by the sequences themselves. `fas2phy.py` converts an aligned FASTA file into a sequential PHYLIP file, ensuring that all sequences are of equal length—a requirement of the format. Conversely, `phy2fas.py` handles the conversion from PHYLIP back to FASTA, supporting both interleaved and sequential PHYLIP variants. This interoperability allows researchers to use high-performance phylogenetic tools like IQ-TREE or RAxML and then return to FASTA-based utilities for downstream processing.
+
+`fas2meg.py` and `phy2meg.py`: Preparing Data for MEGA
+The MEGA (Molecular Evolutionary Genetics Analysis) software is widely used for evolutionary analysis and visualization. It requires a specific format that includes a header and may contain metadata about the sequences. `fas2meg.py` and `phy2meg.py` automate the creation of .meg files from FASTA or PHYLIP inputs, respectively, simplifying the transition from command-line processing to GUI-based exploration.
+
+`fas2csv.py`: Integrating with Data Science Workflows
+For many researchers, the ultimate destination for sequence data is a data science environment like R or Python's Pandas library. `fas2csv.py` converts FASTA records into a simple comma-separated format (name, sequence), allowing for easy import into spreadsheets or data frames. This facilitates large-scale statistical analysis of sequence properties, such as length distributions or k-mer frequencies, across thousands of records.
+
+These conversion tools are more than simple scripts; they are the connective tissue of the EvolCat-Python ecosystem. By automating the tedious task of format conversion, they allow the researcher to focus on the biological questions at hand, ensuring that data flows smoothly from one stage of the pipeline to the next.
+
+
+Precision Genomic Extraction and CDS Analysis
+
+While full-genome analysis is often necessary, many evolutionary questions focus on specific regions or functional units, such as coding sequences (CDS). The EvolCat-Python toolkit provides powerful tools for the precision extraction and analysis of these genomic elements.
+
+`extract_cds_region.py`: The Surgeon's Scalpel
+At the heart of our genomic extraction capabilities is `extract_cds_region.py`. This script is designed to interact deeply with GenBank records, allowing for the extraction of sequences based on either genomic coordinates or single positions.
+
+In "Range Extraction Mode," the user specifies a start and end position. The script not only extracts the nucleotide sequence from that range but also identifies any overlapping CDS features. This is critical because a single genomic region may contain multiple overlapping genes, a common feature in compact viral genomes. For each overlapping CDS, the script reconstructs the full coding sequence, handling complex features like "joins" (multiple exons) and "complements" (reverse strand genes). It then translates the overlapping portion into a protein sequence, correctly accounting for the `codon_start` (reading frame) and the specific NCBI translation table assigned to that gene.
+
+In "Single Position Mode," the script pinpoints a specific nucleotide and determines its role within a coding sequence. It identifies the codon containing the nucleotide, the position of the nucleotide within that codon (1st, 2nd, or 3rd), and the resulting amino acid. This level of detail is invaluable for studying the impact of specific mutations, such as those identified in a VCF file, on the protein product.
+
+`gbCDS.py`: High-Throughput CDS Extraction
+For tasks requiring the extraction of the first CDS from many GenBank records—such as building a dataset of spike proteins from thousands of SARS-CoV-2 genomes—`gbCDS.py` provides a streamlined solution. It iterates through a GenBank file and, for each record, extracts the Locus ID, the nucleotide sequence of the first CDS, and its protein translation. This tool is a workhorse for building the large-scale datasets required for our Transformer-based evolutionary models.
+
+`extract_region.py`: Flexible FASTA Truncation
+Sometimes, extraction is required from FASTA files where detailed annotations are unavailable. `extract_region.py` allows for the simple truncation of FASTA sequences based on 1-based coordinates. While it lacks the CDS-awareness of its GenBank-based counterpart, its simplicity and efficiency make it ideal for preparing sequence "chunks" for alignment or for focusing analysis on a pre-defined region of interest, such as the Receptor-Binding Domain (RBD) of the Spike protein.
+
+These extraction tools empower the researcher to move from the macro-scale of the genome to the micro-scale of the codon and amino acid. By providing both the genomic context and the functional consequences of sequence variation, they form the basis for all downstream selection and phylogenetic analysis in the EvolCat-Python project.
+Multiple Sequence Alignment (MSA) Utilities and Quality Control
+
+Comparison is the essence of evolutionary inference. To identify changes, determine their frequency, and estimate their selective consequences, we must align homologous sequences so that their corresponding positions are compared directly. The EvolCat-Python toolkit provides essential utilities for the analysis and refinement of Multiple Sequence Alignments (MSAs).
+
+`analyze_msa.py`: The Swiss Army Knife of Alignment Analysis
+A robust bioinformatic workflow requires more than just building an alignment; it requires understanding its properties. `analyze_msa.py` is a versatile script that processes alignments from various formats (FASTA, Clustal, PHYLIP, Nexus, Stockholm) to provide critical information.
+
+One of its primary tasks is the generation of a consensus sequence. Using a user-defined threshold, the script identifies the most common character at each position. This consensus can serve as a representative sequence for a viral population or as a reference for detecting rare variants. The script is also "alphabet-aware," meaning it adjusts its behavior based on whether the input is DNA, RNA, or protein, such as defaulting the ambiguous character to 'N' for nucleotides or 'X' for amino acids.
+
+Beyond consensus generation, `analyze_msa.py` provides basic statistics that are vital for quality control. It calculates the alignment length, the number of sequences, the overall GC content, and the proportion of columns containing gaps. This information allows the researcher to quickly identify issues, such as poor-quality sequences that introduce excessive gaps or mis-aligned regions that could bias downstream evolutionary metrics.
+
+`nogaps.py`: Refining Alignments for Metric Calculation
+Many evolutionary metrics, particularly those for calculating substitution rates, require "complete gap deletion." This means that any column containing a gap in even a single sequence must be removed from the analysis. `nogaps.py` automates this process, stripping away all gap-containing columns from an aligned FASTA file. By ensuring that only fully-comparable sites remain, the script provides a clean dataset for tools like `dsdn_dist.py` or `calculate_k2p.py`, preventing the introduction of artifacts caused by missing data.
+
+`pal2nal_enforce.py`: Creating Codon-Aware Nucleotide Alignments
+For selection analysis, nucleotide alignments must be "codon-aware," meaning they must reflect the underlying amino acid sequence and maintain the triplet codon structure. `pal2nal_enforce.py` solves this by taking a protein alignment and the corresponding unaligned nucleotide sequences and "enforcing" the protein's gaps onto the nucleotides. This produces a nucleotide alignment where gaps are always in multiples of three, ensuring that the reading frame is preserved. This is a crucial step before calculating dN/dS or pNC/pNR, as any frame-shift would render those metrics meaningless.
+
+These MSA utilities provide the necessary quality control for all downstream comparative genomics. By ensuring that alignments are clean, well-characterized, and biologically relevant, they allow for the robust calculation of the evolutionary forces acting on viral populations.
+
+
+Quantifying Evolutionary Distance and Selective Pressures
+
+Once we have a high-quality alignment, we can begin to quantify the genetic differences between sequences and infer the selective pressures that have shaped them. The EvolCat-Python toolkit includes a range of tools for calculating evolutionary distance and selection metrics, from simple pairwise measures to complex site-specific models.
+
+`calculate_k2p.py` and `calculate_dna_distances.py`: Measuring Genetic Divergence
+A fundamental measure of evolution is the genetic distance between two sequences. `calculate_k2p.py` implements the Kimura 2-Parameter (K2P) model, which accounts for the difference between transitions (A↔G, C↔T) and transversions (all other substitutions). By calculating the distance, its standard error, and the transition/transversion (Ts/Tv) ratio, the script provides a more accurate estimate of evolutionary change than simple p-distance.
+
+`calculate_dna_distances.py` expands on this, calculating a suite of distance measures including Jukes-Cantor (JC), Tamura-Nei, and Tajima-Nei. This diversity of models allows the researcher to choose the one that best fits the specific evolutionary regime of the virus under study, ensuring that distance estimates are as accurate as possible.
+
+`dsdn_dist.py`: The Nei & Gojobori Method
+Detecting natural selection is a cornerstone of evolutionary biology. `dsdn_dist.py` implements the classic Nei & Gojobori (1986) method for estimating synonymous (dS) and nonsynonymous (dN) substitution rates. By comparing these rates, the script provides the ω ratio (dN/dS), the primary indicator of the type of selection acting on a gene.
+
+This tool is particularly valuable for its implementation of the transition/transversion ratio (R). The user can provide a specific ratio or allow the script to estimate it from the 3rd codon positions of the sequences. This refinement is essential for many viruses, such as SARS-CoV-2, where the substitution process is highly biased toward certain types of mutations. By accounting for this bias, `dsdn_dist.py` provides a more robust and accurate measure of selective pressure.
+
+`pnc_pnr_dist.py`: Probing Biochemical Selection
+While dN/dS is powerful, it treats all amino acid changes as equal. `pnc_pnr_dist.py` provides a more nuanced view by categorizing nonsynonymous substitutions based on amino acid properties. Using the Hughes et al. (1990) method, it calculates the rates of conservative (pNC) and radical (pNR) substitutions.
+
+This tool requires a "property file" that defines the categories of amino acids (e.g., by charge, size, or hydrophobicity). This flexibility allows the researcher to test specific hypotheses about the nature of the selective pressure. For example, in an immune-evasion context, one might expect to see an increase in radical substitutions that alter the charge profile of an epitope. By revealing the biochemical nature of selection, `pnc_pnr_dist.py` provides deeper insights into the mechanisms of viral adaptation.
+
+Integration with PAML Tools
+For more advanced selection analysis, the EvolCat-Python toolkit provides wrappers for the PAML (Phylogenetic Analysis by Maximum Likelihood) package. `calculate_dn_ds.py` uses PAML's `yn00` program for pairwise dN/dS estimation, while `calculate_site_specific_ds_dn.py` wraps the powerful `codeml` program.
+
+`codeml` allows for the analysis of dN/dS variation across different sites in a protein and along different branches of a phylogenetic tree. By testing various models (e.g., M1a, M2a, M7, M8) and using Likelihood Ratio Tests (LRTs), researchers can identify specific amino acid residues that are under positive selection. This is invaluable for identifying the "molecular hotspots" of viral evolution, such as the sites in the SARS-CoV-2 Spike protein that contribute to antibody escape.
+
+These selection metrics and distance tools form the analytical core of our evolutionary investigations. By providing both simple, fast estimators and complex, statistically-rigorous models, the EvolCat-Python toolkit enables the thorough and multi-faceted study of the forces that drive viral diversification.
+Phylogenetic Inference and Ancestral Reconstruction
+
+As we have discussed in Chapter 3, the architecture of viral phylogenetics is a primary lens for studying viral evolution. The EvolCat-Python toolkit includes tools for building phylogenetic trees and reconstructing ancestral sequences, providing a bridge between static sequence data and dynamic evolutionary history.
+
+`build_tree_from_distances.py`: Building Trees from Matrix Data
+While maximum-likelihood methods are often preferred, distance-based methods like Neighbor-Joining (NJ) or UPGMA offer a fast and computationally efficient way to build phylogenetic trees. `build_tree_from_distances.py` takes a distance matrix in PHYLIP or Nexus format—such as one generated by `calculate_dna_distances.py`—and constructs a Newick-formatted tree. This is an essential step for visualizing evolutionary relationships or for providing a starting tree for more complex phylogenetic analyses.
+
+`parsimony_reconstruction.py`: Ancestral Sequence Reconstruction (ASR)
+A cornerstone of our machine-learning workflow is the reconstruction of ancestral sequences. `parsimony_reconstruction.py` implements a two-pass Fitch (1971) parsimony algorithm to infer the sequences of internal nodes in a phylogenetic tree.
+
+In the first pass (root-to-tips), the script propagates the reference (root) sequence down every branch, applying the mutations annotated in the Newick string (the format produced by tools like UShER or matUtils). This produces an initial estimate for every node. In the second pass (tips-to-root), the script applies the parsimony rule: if the intersection of a node's children's base sets is non-empty, the intersection is assigned; otherwise, the union is taken and encoded as an IUPAC ambiguity code.
+
+The output of this script is a set of ancestor-descendant sequence pairs. These pairs serve as the training data for our Transformer-based evolutionary models, allowing them to learn the biophysical rules and mutational constraints that define viral diversification. By providing a dependency-free way to perform ASR on massive, branch-annotated trees, `parsimony_reconstruction.py` enables the study of viral evolution at a scale that was previously unattainable.
+
+These phylogenetic tools empower the researcher to reconstruct the past. By building trees and inferring ancestral states, they provide a temporal dimension to sequence analysis, revealing the historical pathways that lead to contemporary viral diversity.
+
+
+Population-Scale Diversity and Variant Analysis
+
+Viral evolution does not happen in a vacuum; it occurs within the context of a population. To understand the true dynamics of an outbreak, we must be able to scale our analysis to millions of genomes and precisely identify the variants that are driving selective sweeps. The EvolCat-Python toolkit includes tools for population-level diversity calculation and variant filtering.
+
+`calculate_nucleotide_diversity.py`: Quantifying Genomic Variation
+Nucleotide diversity (π) is the fundamental metric for measuring the genetic variation within a population. `calculate_nucleotide_diversity.py` takes a large FASTA alignment and calculates π as the average number of pairwise differences per site.
+
+By systematically applying this script across different time points and geographic regions—as detailed in our advanced global surveillance pipelines—researchers can detect the "diversity collapse" that signals a selective sweep. This tool is a critical part of our ability to track the rise of new variants in real-time and to determine whether their dominance is due to a true fitness advantage or to stochastic factors like founder effects.
+
+`analyze_vcf.py`: Filtering the Signal from the Noise
+The output of a variant-calling pipeline is typically a VCF (Variant Call Format) file. This format is dense with information, including variant quality (QUAL) and read depth (DP) for every mutation identified. `analyze_vcf.py` provides an efficient way to filter these files, removing low-confidence calls and retaining only the variants that meet specified quality and depth criteria.
+
+The script can output a new, filtered VCF or a tab-delimited summary report (CHROM, POS, ID, REF, ALT, QUAL, DP). This summary is ideal for integration with tools like `extract_cds_region.py`, which can then be used to determine the functional consequences of each variant. By providing a clean and reliable set of mutations, `analyze_vcf.py` ensures that our population-scale analyses are based on high-quality genomic evidence.
+
+These population-scale tools are the backbone of our genomic surveillance efforts. By enabling the calculation of π across massive datasets and the rigorous filtering of variant calls, they provide the necessary statistical power to detect and understand the evolutionary shifts that govern global pandemics.
+BLAST Processing and Homology Detection
+
+Detecting homology across diverse viral taxa is a cornerstone of evolutionary biology. The Basic Local Alignment Search Tool (BLAST) remains the gold standard for identifying related sequences. However, raw BLAST output can be dense and difficult to parse. The EvolCat-Python toolkit includes a suite of utilities to transform this output into structured, actionable data.
+
+`parse_blast_text.py` and `blast_to_table.py`: Extracting Structured Data
+Standard text-based BLAST output is designed for human readability but is notoriously difficult for scripts to process. `parse_blast_text.py` is a robust parser that extracts the query ID, subject IDs, e-values, identities, and HSP (High-scoring Segment Pair) coordinates from a standard BLAST run. This provides a clean, machine-readable summary of the homology search.
+
+`blast_to_table.py` goes further, converting the standard text output into a comprehensive tab-delimited table. The resulting table includes columns for Query, Subject_Locus, Subject_Accession, Subject_Length, Subject_Description, P-value, Percent_Identities, and HSP coordinates. By automatically excluding self-hits, the script provides a refined view of the evolutionary relationships between the query and its homologs. This tabular format is ideal for integration with downstream tools like `join_tables.py` for metadata enrichment.
+
+`find_blast_top_pairs.py`: Identifying Orthologs and Reciprocal Hits
+When analyzing large-scale BLAST runs, such as a full genome-by-genome search, researchers often need to identify the single "best" match for each sequence. `find_blast_top_pairs.py` processes a tabular BLAST-like file and identifies unique pairs based on a user-defined score (e.g., bit-score or percent identity).
+
+By ensuring that each query and each subject is assigned to at most one pair, the script provides a simple way to identify putative orthologs. The user can also apply filters, such as a minimum alignment length or a bit-score threshold, to ensure that only high-confidence hits are included. This tool is a workhorse for building the cross-species datasets used for deep evolutionary modeling.
+
+These BLAST processing tools transform a classic bioinformatic task into a modern, automated workflow. By enabling the rapid extraction and filtering of homology data, they provide the foundation for identifying the conserved genes and divergent regions that define viral lineages.
+
+
+General Data Wrangling and Text Matrix Manipulation
+
+Bioinformatics often involves the manipulation of large, tabular datasets and character matrices. The EvolCat-Python toolkit includes a set of general-purpose data wrangling utilities designed for speed and reliability. These tools are often the "unsung heroes" of a complex pipeline, performing the essential tasks of data transformation and integration.
+
+`transpose_tsv.py` and `transpose_text_matrix.py`: Reshaping Data
+Standard tabular data (TSV) and character matrices often need to be "flipped" for different types of analysis. `transpose_tsv.py` performs a traditional matrix transposition on tab-delimited files, switching rows and columns while maintaining their alignment. This is essential for tools that expect data to be organized by site (column-wise) rather than by sequence (row-wise).
+
+`transpose_text_matrix.py` is a specialized version of this logic, designed for raw character strings where each line is a row and each character is an element. This tool is often used to prepare sequence alignments for per-site calculations, such as the Tajima-based per-site π estimator used in our advanced surveillance pipelines.
+
+`join_tables.py`: Integrating Disparate Datasets
+Evolutionary analysis often requires combining sequence-based metrics (e.g., dN/dS) with external metadata (e.g., sample date, geographic location, or clinical outcome). `join_tables.py` mimics a left join from a SQL database, combining two tab-delimited files based on a shared first column. This allows the researcher to quickly build comprehensive datasets for multi-variate statistical analysis, revealing how evolutionary trends correlate with ecological or clinical factors.
+
+`print_duplicate_column_values.py` and `table_to_binary.py`: Data Cleaning and Conversion
+Preparing data for machine learning or statistical modeling often requires specialized cleaning and conversion. `print_duplicate_column_values.py` identifies values that appear more than once across the first two columns of a file—a common way to find sequence pairs that appear multiple times in a dataset.
+
+`table_to_binary.py` converts a numeric table into a binary format (0 or 1) based on a threshold. This is often used to prepare feature matrices for training classifiers or for summarizing the presence/absence of certain traits or variants across a population.
+
+These general data wrangling tools provide the necessary flexibility for handling the diverse data types encountered in viral genomics. By automating the routine tasks of reshaping, joining, and cleaning, they ensure that the data is always in the optimal format for analysis.
+
+
+Integration into Automated Pipelines
+
+The true power of the EvolCat-Python toolkit is realized when these tools are integrated into automated bioinformatic pipelines. Each script is designed with a standard command-line interface, making it easy to chain them together using shell scripts or workflow managers like Snakemake or Nextflow.
+
+A typical workflow might begin with `gb2fasta.py` to extract sequences, followed by `mafft` for alignment, and `analyze_msa.py` for quality control. The refined alignment might then be passed to `dsdn_dist.py` for selection analysis and to `parsimony_reconstruction.py` to generate ancestor-descendant pairs. Finally, `join_tables.py` could be used to merge the evolutionary metrics with metadata for visualization.
+
+By grounding our evolutionary investigations in this modular and automated approach, we ensure that our findings are reproducible and scalable. The EvolCat-Python toolkit provides the necessary building blocks for a modern, data-driven approach to viral genomics, allowing the researcher to move from raw data to scientific belief with precision and confidence.
+A Deep Dive into `extract_cds_region.py`: Biological Nuance and Technical Precision
+
+To illustrate the technical depth of the EvolCat-Python toolkit, let us examine the `extract_cds_region.py` script in detail. This tool is a cornerstone of our precision genomics workflow, bridging the gap between raw genomic coordinates and the functional consequences of sequence variation.
+
+In viral genomics, identifying the correct coding frame and handling reverse-strand genes are frequent challenges. `extract_cds_region.py` addresses these by directly parsing the `FEATURES` table of a GenBank record. When a user requests a range extraction, the script first extracts the raw nucleotide sequence from the `ORIGIN` block. Simultaneously, it identifies every `CDS` feature that overlaps with the requested range.
+
+For each overlapping CDS, the script must handle several biological nuances. First is the `location` string. In GenBank, a CDS location can be a simple range (e.g., `100..500`), a complement (e.g., `complement(100..500)`), or a complex join (e.g., `join(100..200, 300..400)`). The script uses BioPython's location parsing logic to correctly reconstruct the full coding sequence, ensuring that exons are joined in the correct order and that reverse-strand genes are reverse-complemented.
+
+Second is the `codon_start` qualifier. Not all CDS features begin at the first nucleotide of the first exon. Some have an offset of 1 or 2 nucleotides, indicating that the true reading frame starts later. `extract_cds_region.py` respects this qualifier, adjusting the translation frame accordingly. This ensures that the resulting protein sequence is biologically accurate, a prerequisite for any meaningful selection analysis.
+
+Third is the translation itself. The script identifies the `transl_table` assigned to each CDS and uses the corresponding NCBI genetic code for translation. This is particularly important for viruses that may infect diverse hosts with different genetic codes, or for organelle-encoded viral elements.
+
+The single-position mode of `extract_cds_region.py` provides an even finer level of detail. By specifying a single nucleotide position, the researcher can determine exactly how a specific mutation (such as one found in a VCF file) affects the protein. The script identifies the codon containing the position, whether it is the 1st, 2nd, or 3rd base of the codon, and the resulting amino acid. This level of granularity is essential for distinguishing between synonymous mutations (which may be neutral or subject to weak selection on mRNA structure) and nonsynonymous mutations (which change the protein and are often subject to strong selection).
+
+By automating these complex and error-prone tasks, `extract_cds_region.py` provides a reliable foundation for all downstream evolutionary analysis. It transforms the GenBank record from a static annotation into a dynamic and functional genomic model.
+
+
+The Power of Custom Selection Metrics: Implementation of pNC/pNR
+
+As discussed in Chapter 2, the pNC/pNR metric (Hughes et al., 1990) provides a nuanced view of selection by categorizing nonsynonymous substitutions based on amino acid properties. The implementation of this metric in `pnc_pnr_dist.py` demonstrates the toolkit's commitment to biologically-informed computation.
+
+The script begins by reading a user-provided "property file." This file is a simple tab-delimited table that maps each of the 20 standard amino acids to a specific category (e.g., "Positive", "Negative", "Neutral" for charge-based analysis). This allows the researcher to tailor the metric to their specific biological question. For example, if the goal is to study the evolution of viral hydrophobicity, a property file based on the Kyte-Doolittle scale could be used.
+
+Once the properties are defined, the script iterates through all pairs of aligned sequences in a FASTA file. For each pair, it identifies all nonsynonymous differences and classifies them as either "conservative" (the two amino acids belong to the same category) or "radical" (they belong to different categories).
+
+A key challenge in this calculation is the estimation of the number of conservative (NC) and radical (NR) sites. A site is considered conservative if a mutation at that position is expected to result in a conservative amino acid change, and radical if it is expected to be radical. The script calculates these values by considering all possible single-nucleotide mutations for every codon in the sequences and averaging the results.
+
+Like the dN/dS calculation in `dsdn_dist.py`, the pNC/pNR script must account for the transition/transversion bias (R). Transitions are generally more common than transversions, and this bias can significantly affect the expected number of conservative and radical sites. The user can provide a specific R value or allow the script to estimate it from the 3rd codon positions of the alignment.
+
+Finally, the script calculates the proportions pNC = NdC / NC and pNR = NdR / NR, where NdC and NdR are the observed number of conservative and radical nonsynonymous differences, respectively. By comparing these proportions, the researcher can determine whether selection is promoting radical changes in a specific biochemical property—a powerful indicator of adaptive evolution.
+
+The implementation of pNC/pNR in the EvolCat-Python toolkit brings this sophisticated evolutionary metric to the fingertips of the researcher. By providing a flexible and robust implementation that accounts for mutational bias, the toolkit enables the discovery of the specific selective pressures that drive viral diversification.
+
+
+Scalable Population Genomics: The Tajima-Based π Estimator
+
+The calculation of nucleotide diversity (π) for millions of viral genomes presents a significant computational challenge. As described in Chapter 6, our advanced surveillance pipelines use a memory-efficient and statistically-robust π estimator. The implementation of this logic in tools like `calculate_nucleotide_diversity.py` (and its scaled counterparts) is a testament to the toolkit's scalability.
+
+The primary challenge is handling missing data. In large-scale viral sequencing, many genomes have regions of low coverage or "N" characters where the nucleotide could not be determined. A simple pairwise π calculation (averaging the differences between all pairs of sequences) is biased by these "N"s, as it may artificially deflate or inflate the diversity estimate depending on how they are handled.
+
+To address this, the EvolCat-Python toolkit uses a per-site, Tajima-based estimator. For each position in the alignment, the script identifies all sequences that have a valid nucleotide (A, C, G, or T). It then calculates the diversity at that specific site based on the observed allele frequencies. Specifically, it uses the formula π_site = (n / (n-1)) * (1 - Σ p_i^2), where n is the number of valid sequences at the site and p_i is the frequency of the i-th nucleotide.
+
+The final π for the entire alignment is the average of these per-site estimates across all valid positions. This approach ensures that missing data does not bias the results, as each site is calculated only from the sequences that actually provide information.
+
+To handle the massive size of global viral datasets, the pipeline uses memory-mapped NumPy arrays. This allows the script to perform these per-site calculations without loading the entire multi-gigabyte alignment into RAM. The script can "slide" through the genome in chunks, calculating diversity for specific genes or regions of interest with minimal memory overhead.
+
+This scalable and robust approach to population genomics is what allows the EvolCat-Python project to track the evolution of SARS-CoV-2 in real-time. By transforming raw genomic data into high-resolution diversity maps, the toolkit provides the necessary statistical power to detect selective sweeps and to understand the complex dynamics of global pandemics.
+
+
+Phylogenetic Precision: Ancestral State Reconstruction with `parsimony_reconstruction.py`
+
+The reconstruction of ancestral sequences is a critical step in linking phylogenetic history to functional evolution. While maximum-likelihood methods are highly accurate, they can be computationally prohibitive for trees with hundreds of thousands or millions of nodes. `parsimony_reconstruction.py` provides a high-performance, parsimony-based alternative designed specifically for branch-annotated trees.
+
+The input to the script is a Newick string where each branch is annotated with the mutations that distinguish a descendant from its ancestor. This format is produced by tools like UShER and matUtils, which excel at placing new sequences onto existing global phylogenies.
+
+The script's two-pass algorithm is a model of computational efficiency. In the first pass (root-to-tips), it propagates the known reference sequence down the tree, applying the mutations recorded on each branch. This "reconstruction by propagation" provides an initial sequence for every node, including leaves and internal nodes.
+
+In the second pass (tips-to-root), the script applies Fitch's (1971) parsimony algorithm to refine the internal nodes. For each site, it examines the sequences of a node's children. If the children share a set of possible nucleotides (their intersection is non-empty), that set is assigned to the parent. If they share nothing (empty intersection), the parent is assigned the union of all children's bases, and an IUPAC ambiguity code is used to represent the uncertainty.
+
+This combination of propagation and parsimony is the optimal approach for UShER-derived trees. It leverages the detailed mutational history recorded on the branches while using parsimony to handle the inherent uncertainty at deep ancestral nodes.
+
+The utility of this tool extends beyond simple reconstruction. It can output the entire tree of sequences in FASTA format or generate matching pairs of (ancestor, descendant) sequences. These pairs are the essential training data for our Transformer-based models, providing a direct link between the historical process of evolution and the predictive power of machine learning.
+
+Through the implementation of `parsimony_reconstruction.py`, the EvolCat-Python toolkit enables the large-scale study of ancestral states. It provides a robust and efficient way to explore the "evolutionary past," revealing the sequence changes that have led to the emergence of modern viral variants.
 CONCLUSION: EPISTEMOLOGY AND THE FUTURE OF VIRAL SURVEILLANCE
 
 The study of viral genomics is a testament to the power and limitations of the scientific method. As we have explored throughout this volume, the formation of a robust scientific belief about the origins and evolution of viruses depends on a careful integration of empirical data, stochastic modeling, and probabilistic inference.


### PR DESCRIPTION
I have expanded the `VIRAL_EVOLUTION_TEXTBOOK.txt` file with a new, thorough chapter titled "Chapter 7: The EvolCat-Python Toolkit: Implementation and Practical Application". This chapter exceeds 5,000 words and provides a detailed exploration of the repository's bioinformatic tools, their biological relevance, and their technical implementation.

The chapter is organized into several key modules:
- **Data Foundations:** Covers sequence format conversion utilities and precision genomic extraction (with a deep dive into the logic of `extract_cds_region.py`).
- **Comparative Genomics:** Discusses MSA utilities and the calculation of evolutionary distances and selective pressures (including a detailed look at the `pnc_pnr_dist.py` implementation).
- **Phylogenetic and Population Analysis:** Explains the tools for tree building, ancestral state reconstruction (focusing on `parsimony_reconstruction.py`), and population-scale diversity metrics (detailing the Tajima-based $\pi$ estimator).
- **Utility and Integration:** Covers BLAST processing, general data wrangling (TSV/matrix manipulation), and the integration of these tools into automated pipelines.

I also updated the Table of Contents to reflect these changes. All existing tests were run to ensure no regressions, and the new content maintains the established academic tone and citation style of the textbook.

---
*PR created automatically by Jules for task [16723559475544398836](https://jules.google.com/task/16723559475544398836) started by @bob-friedman*